### PR TITLE
Move map creation into modal

### DIFF
--- a/app/channels/campaign_channel.rb
+++ b/app/channels/campaign_channel.rb
@@ -14,22 +14,38 @@ class CampaignChannel < ApplicationCable::Channel
     return if !dm?(campaign) || campaign.current_map == map
 
     campaign.update(current_map: map)
-    broadcast_to(
-      campaign,
-      current_map_html: render_current_map(campaign, admin: false)
-    )
-    broadcast_to(
-      [campaign, campaign.user],
-      current_map_html: render_current_map(campaign, admin: true)
-    )
+    CampaignChannel.broadcast_current_map(campaign)
   end
 
-  private
+  class << self
+    def broadcast_current_map(campaign)
+      broadcast_to(
+        campaign,
+        current_map_html: render_current_map(campaign, admin: false)
+      )
+      broadcast_to(
+        [campaign, campaign.user],
+        current_map_html: render_current_map(campaign, admin: true)
+      )
+    end
 
-  def render_current_map(campaign, admin: false)
-    render_partial(
-      "campaigns/current_map",
-      locals: { campaign: campaign, admin: admin }
-    )
+    def broadcast_map_selector(campaign)
+      broadcast_to(
+        [campaign, campaign.user],
+        map_selector_html: CampaignsController.render(
+          partial: "campaigns/map_selector",
+          locals: { campaign: campaign }
+        )
+      )
+    end
+
+    private
+
+    def render_current_map(campaign, admin: false)
+      CampaignsController.render(
+        partial: "campaigns/current_map",
+        locals: { campaign: campaign, admin: admin }
+      )
+    end
   end
 end

--- a/app/javascript/controllers/campaign_controller.js
+++ b/app/javascript/controllers/campaign_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "stimulus"
 import consumer from "../channels/consumer"
 
 export default class extends Controller {
-  static targets = ["mapOption", "currentMap", "statusIndicator"]
+  static targets = ["mapOption", "currentMap", "statusIndicator", "mapSelector"]
 
   connect() {
     this.campaignId = this.element.dataset.campaignId
@@ -27,6 +27,10 @@ export default class extends Controller {
   }
 
   cableReceived(data) {
-    this.currentMapTarget.innerHTML = data.current_map_html
+    if (data.current_map_html) {
+      this.currentMapTarget.innerHTML = data.current_map_html
+    } else if (data.map_selector_html) {
+      this.mapSelectorTarget.outerHTML = data.map_selector_html
+    }
   }
 }

--- a/app/views/campaigns/_map_selector.html.erb
+++ b/app/views/campaigns/_map_selector.html.erb
@@ -1,17 +1,7 @@
-<div class="map-selector">
-  <% campaign.maps.each do |map| %>
-    <div class="map-selector__option">
-      <%= content_tag :div, nil, class: "map-selector__option-background", style: background_image(map.image) %>
-      <%= content_tag :div, class: "map-selector__option-overlay", data: {
-        action: "click->campaign#chooseMapOption",
-        map_id: map.id
-      } do %>
-        <%= content_tag :span, map.name, class: "map-selector__option-text" %>
-      <% end %>
-    </div>
-  <% end %>
+<div class="map-selector" data-target="campaign.mapSelector">
+  <%= render campaign.maps %>
 
-  <%= link_to new_campaign_map_path(campaign), class: "map-selector__option map-selector__new" do %>
+  <%= link_to new_campaign_map_path(campaign), remote: true, class: "map-selector__option map-selector__new" do %>
     <div class="absolute">
       <span class="">New Map</span>
     </div>

--- a/app/views/maps/_form.html.erb
+++ b/app/views/maps/_form.html.erb
@@ -1,0 +1,23 @@
+<%= form_with model: [map.campaign, map], html: { data: { action: "ajax:success->modal#close ajax:error->modal#onPostError" } } do |form| %>
+  <% if map.errors.any? %>
+    <ul class="errors">
+    <% map.errors.full_messages.each do |error| %>
+      <%= content_tag :li, error %>
+    <% end %>
+    </ul>
+  <% end %>
+
+  <%= form.label :name %>
+  <%= form.text_field :name, class: "input" %>
+
+  <%= form.label :image %>
+  <%= form.file_field :image, class: "input" %>
+
+  <%= form.label :grid_size %>
+  <%= form.text_field :grid_size, class: "input" %>
+
+  <div class="flex items-center justify-between">
+    <%= form.submit class: "btn" %>
+    <%= link_to "Cancel", "#", data: { action: "click->modal#close" }, class: "inline-block align-baseline text-sm text-gray-500 hover:text-gray-800" %>
+  </div>
+<% end %>

--- a/app/views/maps/_map.html.erb
+++ b/app/views/maps/_map.html.erb
@@ -1,0 +1,9 @@
+<div class="map-selector__option">
+  <%= content_tag :div, nil, class: "map-selector__option-background", style: background_image(map.image) %>
+  <%= content_tag :div, class: "map-selector__option-overlay", data: {
+    action: "click->campaign#chooseMapOption",
+    map_id: map.id
+  } do %>
+    <%= content_tag :span, map.name, class: "map-selector__option-text" %>
+  <% end %>
+</div>

--- a/app/views/maps/new.html.erb
+++ b/app/views/maps/new.html.erb
@@ -1,26 +1,7 @@
-<div class="mx-auto max-w-sm">
-  <h1 class="text-4xl">New Map</h1>
+<div class="p-4">
+  <h1 class="text-2xl">New Map</h1>
 
   <hr class="my-2" />
 
-  <%= form_with model: [map.campaign, map], local: true, class: "my-2" do |form| %>
-    <% if map.errors.any? %>
-      <ul class="errors">
-      <% map.errors.full_messages.each do |error| %>
-        <%= content_tag :li, error %>
-      <% end %>
-      </ul>
-    <% end %>
-
-    <%= form.label :name %>
-    <%= form.text_field :name, class: "input" %>
-
-    <%= form.label :image %>
-    <%= form.file_field :image, class: "input" %>
-
-    <%= form.label :grid_size %>
-    <%= form.text_field :grid_size, class: "input" %>
-
-    <%= form.submit class: "btn" %>
-  <% end %>
+  <%= render "form", map: map %>
 </div>


### PR DESCRIPTION
This moves map creation into a modal and remote form. After a map is
created it is set to the current map, and the map selector is refreshed.