### PR TITLE
Editing and deletion of maps

### DIFF
--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -21,6 +21,37 @@ class MapsController < ApplicationController
     end
   end
 
+  def edit
+    respond_to :js
+
+    map = current_user.maps.find(params[:id])
+    render layout: "modal", locals: { map: map }
+  end
+
+  def update
+    map = current_user.maps.find(params[:id])
+    result = UpdateMap.call(
+      campaign: map.campaign,
+      map: map,
+      map_params: map_params
+    )
+    if result.success?
+      head :ok
+    else
+      render partial: "form", locals: { map: map }, status: :bad_request
+    end
+  end
+
+  def destroy
+    map = current_user.maps.find(params[:id])
+    result = DeleteMap.call(campaign: map.campaign, map: map)
+    if result.success?
+      head :ok
+    else
+      head :bad_request
+    end
+  end
+
   private
 
   def map_params

--- a/app/interactors/delete_map.rb
+++ b/app/interactors/delete_map.rb
@@ -1,0 +1,5 @@
+class DeleteMap
+  include Interactor::Organizer
+
+  organize PrepareMapForDeletion, DestroyMap, BroadcastMapSelector
+end

--- a/app/interactors/destroy_map.rb
+++ b/app/interactors/destroy_map.rb
@@ -1,0 +1,9 @@
+class DestroyMap
+  include Interactor
+
+  def call
+    if !context.map.destroy
+      context.fail!
+    end
+  end
+end

--- a/app/interactors/prepare_map_for_deletion.rb
+++ b/app/interactors/prepare_map_for_deletion.rb
@@ -1,0 +1,12 @@
+class PrepareMapForDeletion
+  include Interactor
+
+  def call
+    if context.campaign.current_map == context.map
+      result = ChangeCurrentMap.call(campaign: context.campaign, map: nil)
+      if !result.success?
+        context.fail!
+      end
+    end
+  end
+end

--- a/app/interactors/save_map.rb
+++ b/app/interactors/save_map.rb
@@ -1,0 +1,9 @@
+class SaveMap
+  include Interactor
+
+  def call
+    if !context.map.update(context.map_params)
+      context.fail!
+    end
+  end
+end

--- a/app/interactors/update_map.rb
+++ b/app/interactors/update_map.rb
@@ -1,0 +1,5 @@
+class UpdateMap
+  include Interactor::Organizer
+
+  organize SaveMap, BroadcastCurrentMap, BroadcastMapSelector
+end

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -15,4 +15,9 @@ export default class extends Controller {
   onPostError(event) {
     event.target.outerHTML = event.detail[2].response;
   }
+
+  onDeleteError(event) {
+    event.stopPropagation()
+    alert("There was an problem when attempting to delete.")
+  }
 }

--- a/app/javascript/src/components/_map_selector.scss
+++ b/app/javascript/src/components/_map_selector.scss
@@ -1,3 +1,5 @@
+$map-selector-text-background: rgba(0, 0, 0, 0.5);
+
 .map-selector {
   @apply
     my-4
@@ -19,6 +21,24 @@
     rounded-lg
     mx-3
   ;
+
+  &:hover {
+    .map-selector__option-edit {
+      background-color: $map-selector-text-background;
+      display: block;
+    }
+
+    .map-selector__option-text {
+      @apply
+        rounded
+        bg-black
+        text-white
+        px-2
+      ;
+
+      background-color: $map-selector-text-background;
+    }
+  }
 }
 
 .map-selector__option-background {

--- a/app/views/campaigns/_current_map.html.erb
+++ b/app/views/campaigns/_current_map.html.erb
@@ -8,7 +8,7 @@
     } do %>
     <% if admin %>
       <div class="current-map__token-drawer token-drawer" data-target="map.tokenDrawer" data-action="dragover->map#dragOverDrawer drop->map#dropOnDrawer">
-        <%= link_to new_map_token_path(campaign.current_map), remote: true, title: "New Token", class: "token new-token-link" do %>
+        <%= link_to new_campaign_map_token_path(campaign, campaign.current_map), remote: true, title: "New Token", class: "token new-token-link" do %>
           <span class="token__image token__image-add">+</span>
         <% end %>
 

--- a/app/views/maps/_form.html.erb
+++ b/app/views/maps/_form.html.erb
@@ -17,7 +17,12 @@
   <%= form.text_field :grid_size, class: "input" %>
 
   <div class="flex items-center justify-between">
-    <%= form.submit class: "btn" %>
-    <%= link_to "Cancel", "#", data: { action: "click->modal#close" }, class: "inline-block align-baseline text-sm text-gray-500 hover:text-gray-800" %>
+    <div>
+      <%= form.submit class: "btn" %>
+      <%= link_to "Cancel", "#", data: { action: "click->modal#close" }, class: "inline-block mx-2 align-baseline text-sm text-gray-500 hover:text-gray-800" %>
+    </div>
+    <% if map.persisted? %>
+      <%= link_to "Delete", campaign_map_path(map.campaign, map), method: :delete, remote: true, data: { action: "ajax:error->modal#onDeleteError", confirm: "Are you sure you want to delete #{map.name}?" }, class: "inline-block align-baseline text-sm text-red-500 hover:text-red-800" %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/maps/_map.html.erb
+++ b/app/views/maps/_map.html.erb
@@ -6,4 +6,5 @@
   } do %>
     <%= content_tag :span, map.name, class: "map-selector__option-text" %>
   <% end %>
+  <%= link_to "Edit", edit_campaign_map_path(map.campaign, map), remote: true, class: "map-selector__option-edit hidden absolute top-0 right-0 m-2 rounded inline-block bg-black text-white text-sm px-2" %>
 </div>

--- a/app/views/maps/edit.html.erb
+++ b/app/views/maps/edit.html.erb
@@ -1,0 +1,7 @@
+<div class="p-4">
+  <h1 class="text-2xl">Edit <%= map.name %></h1>
+
+  <hr class="my-2" />
+
+  <%= render "form", map: map %>
+</div>

--- a/app/views/tokens/_item.html.erb
+++ b/app/views/tokens/_item.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag :li, class: "library__item flex items-center pb-2", data: { "#{item.class.name.downcase}-id": item.id } do %>
-  <%= link_to "+", map_tokens_path(item.campaign.current_map, token: { token_template_id: item.id }), method: :post, title: "Add to map", class: "library__image flex-none block bg-cover bg-center inline-block text-center text-lg text-gray-500 rounded-full border-white bg-gray-200 border-2 shadow h-12 w-12 pt-2", style: background_image(item.image) %>
+  <%= link_to "+", campaign_map_tokens_path(item.campaign, item.campaign.current_map, token: { token_template_id: item.id }), method: :post, title: "Add to map", class: "library__image flex-none block bg-cover bg-center inline-block text-center text-lg text-gray-500 rounded-full border-white bg-gray-200 border-2 shadow h-12 w-12 pt-2", style: background_image(item.image) %>
   <span class="library__name flex-1 px-2 whitespace-no-wrap"><%= item.name %></span>
   <%= link_to "Edit", polymorphic_url([item.campaign, item], action: :edit), remote: true, data: { action: "click->modal#removeModal" }, class: "library__edit hidden text-xs text-gray-500 mr-2" %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
   resources :campaigns, only: %i[index new create show] do
     resources :characters, only: %i[create edit update destroy]
     resources :creatures, only: %i[create edit update destroy]
-    resources :maps, only: %i[new create], shallow: true do
+    resources :maps, only: %i[new create edit update destroy] do
       resources :tokens, only: %i[new create]
     end
   end

--- a/spec/interactors/delete_map_spec.rb
+++ b/spec/interactors/delete_map_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe DeleteMap do
+  it "organizes flow of interactors to destroy a map" do
+    expect(described_class.organized).to eq(
+      [
+        PrepareMapForDeletion,
+        DestroyMap,
+        BroadcastMapSelector
+      ]
+    )
+  end
+end

--- a/spec/interactors/destroy_map_spec.rb
+++ b/spec/interactors/destroy_map_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+describe DestroyMap do
+  it "destroys the map" do
+    campaign = instance_double(Campaign, current_map: nil)
+    map = instance_double(Map, destroy: true)
+
+    result = described_class.call(campaign: campaign, map: map)
+
+    expect(result).to be_success
+    expect(map).to have_received(:destroy)
+  end
+
+  describe "when destroying fails" do
+    it "fails the interaction" do
+      campaign = instance_double(Campaign, current_map: nil)
+      map = instance_double(Map, destroy: false)
+
+      result = described_class.call(campaign: campaign, map: map)
+
+      expect(result).not_to be_success
+    end
+  end
+end

--- a/spec/interactors/prepare_map_for_deletion_spec.rb
+++ b/spec/interactors/prepare_map_for_deletion_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe PrepareMapForDeletion do
+  describe "when the given map is the current map" do
+    it "unsets the current map" do
+      map = instance_double(Map)
+      campaign = instance_double(Campaign, current_map: map)
+      result = instance_double(Interactor::Context, success?: true)
+      allow(ChangeCurrentMap).to receive(:call).and_return(result)
+
+      result = described_class.call(campaign: campaign, map: map)
+
+      expect(result).to be_success
+      expect(ChangeCurrentMap)
+        .to have_received(:call).with(campaign: campaign, map: nil)
+    end
+  end
+
+  describe "when the given map is not the current map" do
+    it "does not change the current map" do
+      map = instance_double(Map)
+      campaign = instance_double(Campaign, current_map: nil)
+      allow(ChangeCurrentMap).to receive(:call)
+
+      result = described_class.call(campaign: campaign, map: map)
+
+      expect(result).to be_success
+      expect(ChangeCurrentMap).not_to have_received(:call)
+    end
+  end
+
+  describe "when unsetting the current map fails" do
+    it "fails the interaction the current map" do
+      map = instance_double(Map)
+      campaign = instance_double(Campaign, current_map: map)
+      result = instance_double(Interactor::Context, success?: false)
+      allow(ChangeCurrentMap).to receive(:call).and_return(result)
+
+      result = described_class.call(campaign: campaign, map: map)
+
+      expect(result).not_to be_success
+      expect(ChangeCurrentMap)
+        .to have_received(:call).with(campaign: campaign, map: nil)
+    end
+  end
+end

--- a/spec/interactors/save_map_spec.rb
+++ b/spec/interactors/save_map_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+describe SaveMap do
+  it "updates the map with the given attributes hash" do
+    map = instance_double(Map, update: true)
+    map_params = {}
+
+    result = described_class.call(map: map, map_params: map_params)
+
+    expect(result).to be_success
+    expect(map).to have_received(:update).with(map_params)
+    expect(result.map).to eq map
+  end
+
+  describe "when saving fails" do
+    it "fails the interaction" do
+      map = instance_double(Map, update: false)
+      map_params = {}
+
+      result = described_class.call(map: map, map_params: map_params)
+
+      expect(result).not_to be_success
+      expect(result.map).to eq map
+    end
+  end
+end

--- a/spec/interactors/update_map_spec.rb
+++ b/spec/interactors/update_map_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe UpdateMap do
+  it "organizes flow of interactors for editing a map" do
+    expect(described_class.organized).to eq(
+      [
+        SaveMap,
+        BroadcastCurrentMap,
+        BroadcastMapSelector
+      ]
+    )
+  end
+end

--- a/spec/system/library_spec.rb
+++ b/spec/system/library_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe "manage creatures", type: :system do
     visit campaign_path(campaign, as: campaign.user)
     view_library
     find("[data-creature-id='#{creature.id}']").hover
-    click_on "Edit"
+    within ".library__list" do
+      click_on "Edit"
+    end
     fill_in "Name", with: "New Name"
     click_on "Update Creature"
     view_library
@@ -39,7 +41,9 @@ RSpec.describe "manage creatures", type: :system do
     visit campaign_path(campaign, as: campaign.user)
     view_library
     find("[data-creature-id='#{creature.id}']").hover
-    click_on "Edit"
+    within ".library__list" do
+      click_on "Edit"
+    end
     accept_confirm do
       click_on "Delete #{creature.name}"
     end
@@ -83,7 +87,9 @@ RSpec.describe "manage creatures", type: :system do
     visit campaign_path(campaign, as: campaign.user)
     view_library
     find("[data-character-id='#{character.id}']").hover
-    click_on "Edit"
+    within ".library__list" do
+      click_on "Edit"
+    end
     fill_in "Name", with: "New Name"
     click_on "Update Character"
     view_library
@@ -101,7 +107,9 @@ RSpec.describe "manage creatures", type: :system do
     visit campaign_path(campaign, as: campaign.user)
     view_library
     find("[data-character-id='#{character.id}']").hover
-    click_on "Edit"
+    within ".library__list" do
+      click_on "Edit"
+    end
     accept_confirm do
       click_on "Delete #{character.name}"
     end

--- a/spec/system/manage_maps_spec.rb
+++ b/spec/system/manage_maps_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "manage maps", type: :system do
     end
   end
 
-  it "validates parameters for map" do
+  it "validates parameters for new map" do
     user = create(:user)
     campaign = create :campaign, user: user
     visit campaign_path(campaign, as: user)
@@ -53,6 +53,102 @@ RSpec.describe "manage maps", type: :system do
     fill_in "Name", with: ""
     click_on "Create Map"
     expect(page).to have_content "Name can't be blank"
+  end
+
+  it "can edit a map" do
+    user = create(:user)
+    campaign = create(:campaign, user: user)
+    map = create(:map, campaign: campaign)
+
+    visit campaign_path(campaign, as: user)
+    hover_over_map_selector_for(map)
+    click_on "Edit"
+    fill_in "Name", with: "Edited Map Name"
+    click_on "Update Map"
+
+    expect(page).to have_content "Edited Map Name"
+    expect(map.reload.name).to eq "Edited Map Name"
+  end
+
+  it "can edit a map for other users" do
+    user = create(:user)
+    campaign = create(:campaign, user: user)
+    map = create(:map, campaign: campaign)
+    campaign.update(current_map: map)
+
+    using_session "other user" do
+      visit campaign_path(campaign)
+    end
+
+    visit campaign_path(campaign, as: user)
+    hover_over_map_selector_for(map)
+    click_on "Edit"
+    fill_in "Name", with: "Edited Map Name"
+    click_on "Update Map"
+
+    using_session "other user" do
+      expect(page).to have_content "Edited Map Name"
+    end
+
+    expect(page).to have_content "Edited Map Name"
+    expect(map.reload.name).to eq "Edited Map Name"
+  end
+
+  it "validates parameters when editing maps" do
+    user = create(:user)
+    campaign = create(:campaign, user: user)
+    map = create(:map, campaign: campaign)
+
+    visit campaign_path(campaign, as: user)
+    hover_over_map_selector_for(map)
+    click_on "Edit"
+    fill_in "Name", with: ""
+    click_on "Update Map"
+
+    expect(page).to have_content "Name can't be blank"
+  end
+
+  it "can delete the current map" do
+    user = create(:user)
+    campaign = create(:campaign, user: user)
+    map = create(:map, campaign: campaign)
+    campaign.update(current_map: map)
+
+    visit campaign_path(campaign, as: user)
+    hover_over_map_selector_for(map)
+    click_on "Edit"
+    accept_confirm do
+      click_on "Delete"
+    end
+
+    expect(page).not_to have_content map.name
+    expect(page).to have_content "No Current Map"
+  end
+
+  it "deletes the map for other users" do
+    user = create(:user)
+    campaign = create(:campaign, user: user)
+    map = create(:map, campaign: campaign)
+    campaign.update(current_map: map)
+
+    using_session "other user" do
+      visit campaign_path(campaign)
+    end
+
+    visit campaign_path(campaign, as: user)
+    hover_over_map_selector_for(map)
+    click_on "Edit"
+    accept_confirm do
+      click_on "Delete"
+    end
+
+    using_session "other user" do
+      expect(page).not_to have_content map.name
+      expect(page).to have_content "No Current Map"
+    end
+
+    expect(page).not_to have_content map.name
+    expect(page).to have_content "No Current Map"
   end
 
   it "switches maps" do
@@ -158,6 +254,12 @@ RSpec.describe "manage maps", type: :system do
     using_session "other user" do
       expect(page).to have_css "h2", text: "Gnomengarde"
       expect(page).not_to have_css("[data-target='map.tokenDrawer']")
+    end
+  end
+
+  def hover_over_map_selector_for(map)
+    within "[data-target='campaign.mapSelector']" do
+      find("[data-map-id='#{map.id}']").hover
     end
   end
 end


### PR DESCRIPTION
This adds the ability to edit and delete maps.

Map edits will be rebroadcast to all users. If you delete the current map, it will be unset for everyone.

![Hover to Edit](https://user-images.githubusercontent.com/5015/83362906-0473a900-a363-11ea-805f-c0ebd0763006.gif)

![Edit Modal](https://user-images.githubusercontent.com/5015/83362909-0d647a80-a363-11ea-8fd4-80261a178c96.png)

There is a foreign key constraint on `Campaign#current_map` that ensures the current map cannot be deleted. Therefore, the Deletion Interactor needs to check whether the map being deleted is the current map, and if it is, then it unsets it and broadcasts that before deleting the map.

While I wasn't thrilled with the idea of calling an Interactor from another Interactor, in terms of what this code would look like without Interactors, I think it's at least the same. I also couldn't find any guidance about Interactor best-practices when it comes to this. There is an outstanding PR to add conditionals to Organizers, which we could use it if were merged. 
