### PR TITLE
Explicitely set fallback locale

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,7 +75,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = [I18n.default_locale]
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify


### PR DESCRIPTION
> While doing a bundle install, I saw the following note:
>
> HEADS UP! i18n 1.1 changed fallbacks to exclude default locale.
> But that may break your application.
>
> If you are upgrading your Rails application from an older version of
> Rails:
>
> Please check your Rails app for 'config.i18n.fallbacks = true'.
> If you're using I18n (>= 1.1.0) and Rails (< 5.2.2), this should be
> 'config.i18n.fallbacks = [I18n.default_locale]'.
> If not, fallbacks will be broken in your app by I18n 1.1.x.
>
> If you are starting a NEW Rails application, you can ignore this
> notice.
>
> For more info see:
> https://github.com/svenfuchs/i18n/releases/tag/v1.1.0

This makes the recommended change.