### PR TITLE
Improve sponsor code experience

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,11 +1,13 @@
 class UsersController < Clearance::UsersController
   def create
     @user = user_from_params
+    result = CreateUser.call(sponsor_code: params[:sign_up_code], user: @user)
 
-    if sign_up_code_correct && @user.save
+    if result.success?
       sign_in @user
       redirect_back_or url_after_create
     else
+      flash.now[:error] = result.message
       render template: "users/new"
     end
   end
@@ -18,10 +20,6 @@ class UsersController < Clearance::UsersController
     else
       Hash.new
     end
-  end
-
-  def sign_up_code_correct
-    params[:sign_up_code] == ENV["SIGN_UP_CODE"]
   end
 
   def url_after_create

--- a/app/interactors/create_user.rb
+++ b/app/interactors/create_user.rb
@@ -1,0 +1,5 @@
+class CreateUser
+  include Interactor::Organizer
+
+  organize ValidateSponsorCode, SaveUser
+end

--- a/app/interactors/save_user.rb
+++ b/app/interactors/save_user.rb
@@ -1,0 +1,9 @@
+class SaveUser
+  include Interactor
+
+  def call
+    if !context.user.save
+      context.fail!(message: "Error saving user")
+    end
+  end
+end

--- a/app/interactors/validate_sponsor_code.rb
+++ b/app/interactors/validate_sponsor_code.rb
@@ -1,0 +1,14 @@
+class ValidateSponsorCode
+  include Interactor
+  include ApplicationHelper
+
+  def call
+    if context.sponsor_code != ENV["SIGN_UP_CODE"]
+      context.fail!(message: I18n.t(
+        "incorrect_sponsor_code_html",
+        support_email: support_email,
+        patreon_url: patreon_url
+      ).html_safe)
+    end
+  end
+end

--- a/app/javascript/src/components/_flashes.scss
+++ b/app/javascript/src/components/_flashes.scss
@@ -1,11 +1,23 @@
 .flash-error {
   @apply bg-red-100 border-red-500 text-red-700;
+
+  a {
+    @apply underline;
+  }
 }
 
 .flash-notice {
   @apply bg-blue-100 border-blue-500 text-blue-700;
+
+  a {
+    @apply underline;
+  }
 }
 
 .flash-success {
   @apply bg-green-100 border-green-500 text-green-700;
+
+  a {
+    @apply underline;
+  }
 }

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,3 +1,5 @@
+<%= render "errors", model: form.object %>
+
 <div class="text-field">
   <%= form.label :name %>
   <%= form.text_field :name, class: "input"%>
@@ -15,6 +17,6 @@
 
 <div class="text-field">
   <%= label_tag :sign_up_code %>
-  <span class="text-sm text-gray-500">Available to <a href="https://www.patreon.com/tableparty" class="text-blue-500 hover:text-blue-800">Patreon supporters</a></span>
+  <span class="text-sm text-gray-500">Available to <%= link_to "Patreon supporters", patreon_url, class: "text-blue-500 hover:text-blue-800" %></span>
   <%= text_field_tag :sign_up_code, nil, class: "input" %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,10 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  incorrect_sponsor_code_html: >
+    Incorrect sponsor code. If you have a sponsor code, please double-check it.
+    If you can offer your support then we'd love for you to
+    <a href="%{patreon_url}">join us on Patreon</a>.
+    If you can't financially back the project but would still like to be
+    involved in testing, please email
+    <a href="mailto:%{support_email}">%{support_email}</a>.

--- a/spec/interactors/create_user_spec.rb
+++ b/spec/interactors/create_user_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe CreateUser do
+  it "organizes flow of interactors to create a user" do
+    expect(described_class.organized).to eq(
+      [
+        ValidateSponsorCode,
+        SaveUser
+      ]
+    )
+  end
+end

--- a/spec/interactors/save_user_spec.rb
+++ b/spec/interactors/save_user_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+describe SaveUser do
+  context "when saving succeeds" do
+    it "saves the users in the context" do
+      user = instance_double(User, save: true)
+
+      result = described_class.call(user: user)
+
+      expect(result).to be_success
+      expect(user).to have_received(:save)
+      expect(result.user).to eq user
+    end
+
+    it "does not add an error message" do
+      user = instance_double(User, save: true)
+
+      result = described_class.call(user: user)
+
+      expect(result.message).to be_blank
+    end
+  end
+
+  describe "when saving fails" do
+    it "fails the interaction" do
+      user = instance_double(User, save: false)
+
+      result = described_class.call(user: user)
+
+      expect(result).not_to be_success
+      expect(user).to have_received(:save)
+      expect(result.user).to eq user
+    end
+
+    it "adds an error message" do
+      user = instance_double(User, save: false)
+
+      result = described_class.call(user: user)
+
+      expect(result.message).to be_present
+    end
+  end
+end

--- a/spec/interactors/validate_sponsor_code_spec.rb
+++ b/spec/interactors/validate_sponsor_code_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+describe ValidateSponsorCode do
+  include ApplicationHelper
+
+  context "when the code is correct" do
+    it "succeeds the interaction" do
+      result = described_class.call(sponsor_code: ENV["SIGN_UP_CODE"])
+
+      expect(result).to be_success
+      expect(result.message).to be_blank
+    end
+  end
+
+  context "when the code is incorrect" do
+    it "fails the interaction" do
+      result = described_class.call(sponsor_code: "incorrect")
+
+      expect(result).not_to be_success
+      expect(result.message).to eq(
+        I18n.t(
+          "incorrect_sponsor_code_html",
+          support_email: support_email,
+          patreon_url: patreon_url
+        ).html_safe
+      )
+    end
+  end
+end

--- a/spec/system/clearance/visitor_signs_up_spec.rb
+++ b/spec/system/clearance/visitor_signs_up_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe "Visitor signs up", type: :system do
   it "tries with wrong code" do
     sign_up_with "Name", "valid@example.com", "password", "howaboutthis?"
 
+    expect(page).to have_content("Incorrect sponsor code")
     expect_user_to_be_signed_out
   end
 end


### PR DESCRIPTION
Fixes #79. This change attempts to address the experience our user had
in #79 by presenting a meaningful error message when not providing a
sponsor code, or providing one that doesn't match.

The copy provided is based on what @jdbann said in the issue.

Instead of continuing to modify the controller, I took the opportunity
to extract this to Interactors.

![Screen Shot 2020-06-14 at 2 59 14 PM](https://user-images.githubusercontent.com/5015/85206801-769c3580-b2f2-11ea-99e3-7a6ebb10ebd3.png)
