### PR TITLE
Remove map and token jitter

### DIFF
--- a/app/channels/map_channel.rb
+++ b/app/channels/map_channel.rb
@@ -13,6 +13,7 @@ class MapChannel < ApplicationCable::Channel
         map,
         {
           operation: "move",
+          operator: data["operator"],
           x: map.x,
           y: map.y
         }
@@ -50,6 +51,7 @@ class MapChannel < ApplicationCable::Channel
       map,
       {
         operation: "moveToken",
+        operator: data["operator"],
         token_id: token.id,
         x: token.x,
         y: token.y

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -6,6 +6,7 @@ export default class extends Controller {
 
   connect() {
     this.mapId = this.element.dataset.mapId
+    this.operatorCode = this.generateOperatorCode()
 
     this.setViewportSize()
     this.updateZoomButtons()
@@ -80,6 +81,7 @@ export default class extends Controller {
         this.channel.perform(
           "move_map",
           {
+            operator: this.operatorCode,
             map_id: this.mapId,
             x: this.imageTarget.dataset.x,
             y: this.imageTarget.dataset.y
@@ -183,6 +185,7 @@ export default class extends Controller {
         "move_token",
         {
           map_id: this.mapId,
+          operator: this.operatorCode,
           token_id: tokenId,
           x: target.dataset.x,
           y: target.dataset.y
@@ -216,7 +219,7 @@ export default class extends Controller {
   cableReceived(data) {
     switch (data.operation) {
       case "move": {
-        if (this.imageTarget.dataset.beingDragged) {
+        if (this.imageTarget.dataset.beingDragged || data.operator === this.operatorCode) {
           return
         }
         this.setMapPosition(data.x, data.y)
@@ -229,7 +232,7 @@ export default class extends Controller {
       }
       case "moveToken": {
         const token = this.findToken(data.token_id)
-        if (token.dataset.beingDragged) {
+        if (token.dataset.beingDragged || data.operator === this.operatorCode) {
           return
         }
         this.setTokenLocation(token, data.x, data.y)
@@ -319,4 +322,9 @@ export default class extends Controller {
     }
   }
 
+  generateOperatorCode() {
+    return Array
+      .from(window.crypto.getRandomValues(new Uint8Array(32)))
+      .map(c => (c < 16 ? "0" : "") + c.toString(16)).join([]);
+  }
 }


### PR DESCRIPTION
Fixes #85

Previously, the token and map movement was relayed to everyone on the page,
including the person moving it, even though their browser had already
moved the item.

The movement was blocked while the token or map was being dragged, but
when it was released, rapid movements were likely to still be coming
over the cable.

This resolves the issue by having each person on the page ignore any of
their own map or token movements.

![No Jitter](https://user-images.githubusercontent.com/5015/84602809-f4c28d00-ae57-11ea-8837-e93cf5dafbd1.gif)

This is accomplished by having each person on the page generate a unique
"operator code". This code is sent along with the move map or token
operations. When operations are received on the channel, much like
ignoring the operation if `beingDragged` is true, the operation is ignored
if you were the one who did it.