### PR TITLE
Improve signup/register on mobile devices

### DIFF
--- a/app/views/layouts/sessions.html.erb
+++ b/app/views/layouts/sessions.html.erb
@@ -8,10 +8,11 @@
 
     <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
 
-  <body class="bg-gray-200 h-screen flex justify-center items-center">
-    <div class="w-full max-w-sm">
+  <body class="bg-gray-200 md:h-screen flex justify-center items-center m-8 md:mx-0">
+    <div class="w-full md:max-w-sm">
       <%= render "flashes" %>
 
       <div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">


### PR DESCRIPTION
Fixes #41. Improves the layout on the signup and register pages for
mobile devices.

### Before

![IMG_2199](https://user-images.githubusercontent.com/5015/85208013-1bbb0c00-b2fb-11ea-96d9-6cb00ccb9083.png)

### After

![IMG_2200](https://user-images.githubusercontent.com/5015/85208014-1fe72980-b2fb-11ea-9c55-adcc34f4a376.png)

![IMG_2201](https://user-images.githubusercontent.com/5015/85208015-21b0ed00-b2fb-11ea-97a7-bba343f618f5.png)
