### PR TITLE
Extract map and token position syncing to SyncValuesController

### DIFF
--- a/app/channels/map_channel.rb
+++ b/app/channels/map_channel.rb
@@ -18,24 +18,6 @@ class MapChannel < ApplicationCable::Channel
     map.update(zoom: data["zoom"])
   end
 
-  def move_token(data)
-    map = Map.find(data["map_id"])
-    token = map.tokens.find(data["token_id"])
-    return if token.x == data["x"] && token.y == data["y"]
-
-    token.update(x: data["x"], y: data["y"])
-    broadcast_to(
-      map,
-      {
-        operation: "moveToken",
-        operator: data["operator"],
-        token_id: token.id,
-        x: token.x,
-        y: token.y
-      }
-    )
-  end
-
   def stash_token(data)
     map = Map.find(data["map_id"])
     token = map.tokens.find(data["token_id"])

--- a/app/channels/map_channel.rb
+++ b/app/channels/map_channel.rb
@@ -5,7 +5,7 @@ class MapChannel < ApplicationCable::Channel
   end
 
   def move_map(data)
-    map = Map.find(data["map_id"])
+    map = Map.find(data["id"])
     return if !dm?(map.campaign) || map.x == data["x"] && map.y == data["y"]
 
     map.update(x: data["x"], y: data["y"])

--- a/app/channels/token_channel.rb
+++ b/app/channels/token_channel.rb
@@ -1,0 +1,21 @@
+class TokenChannel < ApplicationCable::Channel
+  def subscribed
+    token = Token.find(params[:id])
+    stream_for token
+  end
+
+  def move(data)
+    token = Token.find(data["id"])
+    return if token.x == data["x"] && token.y == data["y"]
+
+    token.update(x: data["x"], y: data["y"])
+    broadcast_to(
+      token,
+      {
+        operator: data["operator"],
+        x: token.x,
+        y: token.y
+      }
+    )
+  end
+end

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -192,17 +192,6 @@ export default class extends Controller {
         newX,
         newY
       )
-
-      this.channel.perform(
-        "move_token",
-        {
-          map_id: this.mapId,
-          operator: this.operatorCode,
-          token_id: tokenId,
-          x: target.dataset.x,
-          y: target.dataset.y
-        }
-      )
     }
   }
 
@@ -222,14 +211,6 @@ export default class extends Controller {
 
   cableReceived(data) {
     switch (data.operation) {
-      case "moveToken": {
-        const token = this.findToken(data.token_id)
-        if (token.dataset.beingDragged || data.operator === this.operatorCode) {
-          return
-        }
-        this.setTokenLocation(token, data.x, data.y)
-        break
-      }
       case "addToken": {
         if (this.findToken(data.token_id)) {
           return

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -79,15 +79,6 @@ export default class extends Controller {
           original.x - ((mousepos.x - mousedown.x) * speedFactor),
           original.y - ((mousepos.y - mousedown.y) * speedFactor)
         )
-        this.channel.perform(
-          "move_map",
-          {
-            operator: this.operatorCode,
-            map_id: this.mapId,
-            x: this.imageTarget.dataset.x,
-            y: this.imageTarget.dataset.y
-          }
-        )
       }
     }
     document.addEventListener("mouseup", () => {

--- a/app/javascript/controllers/sync_values_controller.js
+++ b/app/javascript/controllers/sync_values_controller.js
@@ -1,0 +1,82 @@
+import { Controller } from "stimulus"
+import consumer from "../channels/consumer"
+
+export default class extends Controller {
+  connect() {
+    this.syncedVariables = this.data.get("keys").split(" ")
+    this.operatorCode = this.generateOperatorCode()
+
+    this.initializeObserver()
+    this.initializeChannel()
+
+    this.connectObserver()
+  }
+
+  disconnect() {
+    this.observer.disconnect()
+  }
+
+  cableReceived(data) {
+    if(data["operator"] == this.operatorCode) {
+      return
+    }
+
+    this.disconnectObserver()
+
+    this.syncedVariables.forEach(variable => {
+      this.element.dataset[variable] = data[variable]
+    })
+
+    this.connectObserver()
+  }
+
+  initializeChannel() {
+    this.channel = consumer.subscriptions.create({
+      channel: this.data.get("channel"),
+      id: this.data.get("channelId")
+    }, {
+      received: this.cableReceived.bind(this)
+    })
+  }
+
+  initializeObserver() {
+    this.observerOptions = {
+      attributes: true,
+      attributeFilter: this.syncedVariables.map(this.variableNameToDataAttribute)
+    }
+
+    this.observer = new MutationObserver(mutations => {
+      const attributes = mutations.reduce((changedAttributes, mutation) => {
+        const varName = this.dataAttributeToVariableName(mutation.attributeName)
+        changedAttributes[varName] = mutation.target.dataset[varName]
+        return changedAttributes
+      }, {
+        operator: this.operatorCode,
+        id: this.data.get("channelId")
+      })
+      this.channel.perform(this.data.get("action"), attributes)
+    })
+  }
+
+  connectObserver() {
+    this.observer.observe(this.element, this.observerOptions)
+  }
+
+  disconnectObserver() {
+    this.observer.disconnect()
+  }
+
+  variableNameToDataAttribute(variableName) {
+    return `data-${variableName}`
+  }
+
+  dataAttributeToVariableName(dataName) {
+    return dataName.match(/data-(.+)/)[1]
+  }
+
+  generateOperatorCode() {
+    return Array
+      .from(window.crypto.getRandomValues(new Uint8Array(32)))
+      .map(c => (c < 16 ? "0" : "") + c.toString(16)).join([]);
+  }
+}

--- a/app/views/campaigns/_current_map.html.erb
+++ b/app/views/campaigns/_current_map.html.erb
@@ -18,7 +18,7 @@
     <%= content_tag :div,
       class: "current-map relative overflow-hidden",
       data: {
-        controller: "css-var",
+        controller: "css-var #{"sync-values" if admin}",
         "map-id": campaign.current_map.id,
         target: "map.image #{"map--fog.image" if campaign.current_map.fog_enabled?}",
         action: "dragover->map#dragOverMap drop->map#dropOnMap mousedown->map#pointTo #{"mousedown->map--fog#startDrawingFog" if campaign.current_map.fog_enabled? && admin} mousedown->map#moveMap",
@@ -32,7 +32,11 @@
         height: campaign.current_map.height,
         width: campaign.current_map.width,
         "zoom-max": campaign.current_map.zoom_max,
-        "css-vars": "x y viewport-x viewport-y original-width original-height zoom-amount"
+        "css-vars": "x y viewport-x viewport-y original-width original-height zoom-amount",
+        "sync-values-channel": "MapChannel",
+        "sync-values-action": "move_map",
+        "sync-values-channel-id": campaign.current_map.id,
+        "sync-values-keys": "x y"
       },
       style: background_image(campaign.current_map.image) do %>
       <div class="current-map__token-container" data-target="map.tokenContainer">

--- a/app/views/tokens/_token.html.erb
+++ b/app/views/tokens/_token.html.erb
@@ -2,7 +2,7 @@
   class: "token",
   draggable: true,
   data: {
-    controller: "css-var",
+    controller: "css-var sync-values",
     target: "map.token",
     action: "dragstart->map#startMoveToken drag->map#moveToken dragend->map#endMoveToken mousedown->map#stopPropagation",
     token_id: token.id,
@@ -10,7 +10,11 @@
     y: token.y,
     "size-scale": token.size_scale,
     copy_on_place: token.copy_on_place?,
-    "css-vars": "x y size-scale"
+    "css-vars": "x y size-scale",
+    "sync-values-channel": "TokenChannel",
+    "sync-values-action": "move",
+    "sync-values-channel-id": token.id,
+    "sync-values-keys": "x y"
   } do %>
   <%= content_tag :div, "", class: "token__image", style: background_image(token.image) do %>
     <% if token.identifier.present? %>


### PR DESCRIPTION
Introduces a new `SyncValuesController` with Stimulus.

Supposing we have an HTML element we wish to drag around the page, we would keep track of the current position with data attributes:

```html
<div
  data-x="100"
  data-y="100"
  data-controller="draggable"
  >
</div>
```

If we wish to communicate the coordinates in realtime with other users on the page, we have previously been adding an ActionCable channel to the `DraggableController` which would then take also responsibility for managing the channel, sending updated values and updating local values when receiving new values from the server.

To separate out this responsibility, this PR introduces the `SyncValuesController`. We can specify which data attributes should be synced and the channel, id and action we should send/receive this information to/from:

```html
<div
  data-x="100"
  data-y="100"
  data-controller="draggable sync-values"
  data-sync-values-channel="PositionChannel"
  data-sync-values-channel-id="123"
  data-sync-values-action="update_position"
  data-sync-values-keys="x y"
  >
</div>
```

When connected to the DOM, the `SyncValuesController`:

- sets up a new `MutationObserver` which monitors changes to the data attributes specified in `data-sync-values-keys`
- sets up a new channel connected to `data-sync-values-channel`, passing the id from `data-sync-values-channel-id`

When the `MutationObserver` catches changes to the specified values it:

- reduces the changed values to a single payload which also includes the `data-sync-values-channel-id` and an `operator`
- produces the payload to the channel, for the action provided in `data-sync-values-action`

When the channel receives a message it:

- Returns early if the operator code in the message matches the local operator code (as this means the message came from the `SyncValuesController`)
- Disables the `MutationObserver`
- Updates the data attributes with the values from the message
- Restarts the `MutationObserver`

Disabling and restarting the `MutationObserver` prevents us from ending up in an infinite loop of values being synced.

This `SyncValuesController` is applied to map and token movement.