### PR TITLE
Move map image, token container and fog with CSS transforms

### DIFF
--- a/app/javascript/src/components/_fog.scss
+++ b/app/javascript/src/components/_fog.scss
@@ -4,12 +4,15 @@ $mask-color: #000;
 $mask-dm-opacity: 0.5;
 
 .fog {
-  height: calc(var(--original-height) * var(--zoom-amount) * 1px);
-  left: calc(((var(--viewport-x) / 2) - (var(--x) * var(--zoom-amount))) * 1px);
+  height: calc(var(--original-height) * 1px);
   pointer-events: none;
   position: absolute;
-  top: calc(((var(--viewport-y) / 2) - (var(--y) * var(--zoom-amount))) * 1px);
-  width: calc(var(--original-width) * var(--zoom-amount) * 1px);
+  transform: translateX(calc(((var(--viewport-x) / 2) - (var(--x) * var(--zoom-amount))) * 1px))
+    translateY(calc(((var(--viewport-y) / 2) - (var(--y) * var(--zoom-amount))) * 1px))
+    scaleX(var(--zoom-amount))
+    scaleY(var(--zoom-amount));
+  transform-origin: 0 0 0;
+  width: calc(var(--original-width) * 1px);
 }
 
 .fog__layer {

--- a/app/javascript/src/components/_fog.scss
+++ b/app/javascript/src/components/_fog.scss
@@ -9,6 +9,7 @@ $mask-dm-opacity: 0.5;
   position: absolute;
   transform: translateX(calc(((var(--viewport-x) / 2) - (var(--x) * var(--zoom-amount))) * 1px))
     translateY(calc(((var(--viewport-y) / 2) - (var(--y) * var(--zoom-amount))) * 1px))
+    translateZ(0)
     scaleX(var(--zoom-amount))
     scaleY(var(--zoom-amount));
   transform-origin: 0 0 0;

--- a/app/javascript/src/components/_map.scss
+++ b/app/javascript/src/components/_map.scss
@@ -13,11 +13,14 @@
 
 .current-map__image {
   background-size: cover;
-  height: calc(var(--original-height) * var(--zoom-amount) * 1px);
-  left: calc(((var(--viewport-x) / 2) - (var(--x) * var(--zoom-amount))) * 1px);
+  height: calc(var(--original-height) * 1px);
   position: absolute;
-  top: calc(((var(--viewport-y) / 2) - (var(--y) * var(--zoom-amount))) * 1px);
-  width: calc(var(--original-width) * var(--zoom-amount) * 1px);
+  transform: translateX(calc(((var(--viewport-x) / 2) - (var(--x) * var(--zoom-amount))) * 1px))
+    translateY(calc(((var(--viewport-y) / 2) - (var(--y) * var(--zoom-amount))) * 1px))
+    scaleX(var(--zoom-amount))
+    scaleY(var(--zoom-amount));
+  transform-origin: 0 0 0;
+  width: calc(var(--original-width) * 1px);
 }
 
 .current-map__token-container {

--- a/app/javascript/src/components/_map.scss
+++ b/app/javascript/src/components/_map.scss
@@ -1,10 +1,6 @@
 .current-map {
   @apply w-full;
 
-  background-position-x: calc(((var(--viewport-x) / 2) - (var(--x) * var(--zoom-amount))) * 1px);
-  background-position-y: calc(((var(--viewport-y) / 2) - (var(--y) * var(--zoom-amount))) * 1px);
-  background-repeat: no-repeat;
-  background-size: calc(var(--original-width) * var(--zoom-amount) * 1px) calc(var(--original-height) * var(--zoom-amount) * 1px);
   cursor: move;
   user-select: none;
 
@@ -13,6 +9,15 @@
       @apply cursor-not-allowed text-gray-400;
     }
   }
+}
+
+.current-map__image {
+  background-size: cover;
+  height: calc(var(--original-height) * var(--zoom-amount) * 1px);
+  left: calc(((var(--viewport-x) / 2) - (var(--x) * var(--zoom-amount))) * 1px);
+  position: absolute;
+  top: calc(((var(--viewport-y) / 2) - (var(--y) * var(--zoom-amount))) * 1px);
+  width: calc(var(--original-width) * var(--zoom-amount) * 1px);
 }
 
 .current-map__token-container {

--- a/app/javascript/src/components/_map.scss
+++ b/app/javascript/src/components/_map.scss
@@ -24,10 +24,10 @@
 }
 
 .current-map__token-container {
-  @apply relative;
+  @apply absolute;
 
-  left: calc(((var(--viewport-x) / 2) - (var(--x) * var(--zoom-amount))) * 1px);
-  top: calc(((var(--viewport-y) / 2) - (var(--y) * var(--zoom-amount))) * 1px);
+  transform: translateX(calc(((var(--viewport-x) / 2) - (var(--x) * var(--zoom-amount))) * 1px))
+    translateY(calc(((var(--viewport-y) / 2) - (var(--y) * var(--zoom-amount))) * 1px));
 }
 
 .current-map__map-name {

--- a/app/javascript/src/components/_map.scss
+++ b/app/javascript/src/components/_map.scss
@@ -17,6 +17,7 @@
   position: absolute;
   transform: translateX(calc(((var(--viewport-x) / 2) - (var(--x) * var(--zoom-amount))) * 1px))
     translateY(calc(((var(--viewport-y) / 2) - (var(--y) * var(--zoom-amount))) * 1px))
+    translateZ(0)
     scaleX(var(--zoom-amount))
     scaleY(var(--zoom-amount));
   transform-origin: 0 0 0;
@@ -27,7 +28,8 @@
   @apply absolute;
 
   transform: translateX(calc(((var(--viewport-x) / 2) - (var(--x) * var(--zoom-amount))) * 1px))
-    translateY(calc(((var(--viewport-y) / 2) - (var(--y) * var(--zoom-amount))) * 1px));
+    translateY(calc(((var(--viewport-y) / 2) - (var(--y) * var(--zoom-amount))) * 1px))
+    translateZ(0);
 }
 
 .current-map__map-name {

--- a/app/views/campaigns/_current_map.html.erb
+++ b/app/views/campaigns/_current_map.html.erb
@@ -37,8 +37,8 @@
         "sync-values-action": "move_map",
         "sync-values-channel-id": campaign.current_map.id,
         "sync-values-keys": "x y"
-      },
-      style: background_image(campaign.current_map.image) do %>
+      } do %>
+      <%= content_tag :div, "", class: "current-map__image", style: background_image(campaign.current_map.image) %>
       <div class="current-map__token-container" data-target="map.tokenContainer">
         <%= render campaign.current_map.tokens.where(stashed: false) %>
       </div>


### PR DESCRIPTION
3D CSS transformations are automatically handled by the GPU where possible. This PR changes the styling of the map image, the token container and the fog to be positioned and scaled using CSS transformations and applies `translateZ(0)` to ensure they run as 3D transformations.

To achieve this, the map image has been moved to its own `<div>` element and is no longer positioned with `background-position`