### PR TITLE
Present fog with canvas instead of SVG

### DIFF
--- a/app/helpers/fog_helper.rb
+++ b/app/helpers/fog_helper.rb
@@ -1,0 +1,21 @@
+module FogHelper
+  def serialize_fog_areas(fog_areas)
+    safe_join(
+      [
+        "[",
+        safe_join(
+          fog_areas.map do |fog_area|
+            safe_join(
+              [
+                "{ \"id\": \"#{fog_area.id}\", \"path\": ",
+                fog_area.path,
+                " }"
+              ]
+            )
+          end, ", "
+        ),
+        "]"
+      ]
+    )
+  end
+end

--- a/app/javascript/controllers/map/fog_controller.js
+++ b/app/javascript/controllers/map/fog_controller.js
@@ -3,7 +3,7 @@ import { v4 as uuid } from "uuid"
 import consumer from "../../channels/consumer"
 
 export default class extends Controller {
-  static targets = ["image", "fogMask", "fogArea"]
+  static targets = ["image", "canvas"]
 
   connect() {
     this.mapId = this.element.dataset.mapId
@@ -14,6 +14,39 @@ export default class extends Controller {
     }, {
       received: this.cableReceived.bind(this)
     })
+
+    this.drawCanvas()
+  }
+
+  drawCanvas() {
+    const fogAreas = this.fogAreas
+    let stillAnimating = false
+
+    const ctx = this.canvasTarget.getContext('2d')
+    ctx.globalCompositeOperation = "source-over"
+    ctx.fillRect(0, 0, this.canvasTarget.width, this.canvasTarget.height)
+    ctx.globalCompositeOperation = "destination-out"
+
+    fogAreas.forEach(area => {
+      const fadeDuration = 1000.0
+      const addedAt = area.addedAt || 0
+      const timeDiff = (fadeDuration - Math.min((Date.now() - addedAt), fadeDuration)) / fadeDuration
+      if (timeDiff > 0.0 && !stillAnimating) {
+        stillAnimating = true
+      }
+      ctx.fillStyle = `rgba(0, 0, 0, ${1.0 - timeDiff})`
+
+      ctx.beginPath()
+      for(const { x, y } of area.path) {
+        ctx.lineTo(x, y)
+      }
+      ctx.fill()
+      ctx.closePath()
+    })
+
+    if (stillAnimating) {
+      window.requestAnimationFrame(this.drawCanvas.bind(this))
+    }
   }
 
   disconnect() {
@@ -32,43 +65,62 @@ export default class extends Controller {
   cableReceived(data) {
     switch (data.operation) {
       case "revealArea": {
-        if (!this.fogAreaTargets.find(area => area.dataset.id == data.id)) {
-          this.addFogArea(data.id, data.path)
+        if (!this.getFogArea(data.id)) {
+          this.createFogArea(data.id, JSON.parse(data.path))
         }
       }
     }
   }
 
-  addFogArea(id, path) {
-    const fogPath = document.createElementNS("http://www.w3.org/2000/svg", "path")
-    fogPath.setAttribute("class", "fog__revealed")
-    fogPath.setAttribute('d', path)
-    fogPath.dataset.target = "map--fog.fogArea"
-    fogPath.dataset.id = id
-    this.fogMaskTarget.appendChild(fogPath)
-    return fogPath
+  createFogArea(id, path) {
+    const areas = this.fogAreas
+    this.fogAreas = [...areas, { id: id, path: path, addedAt: Date.now() }]
+    this.drawCanvas()
+  }
+
+  addFogArea(id, x, y) {
+    const areas = this.fogAreas
+    this.fogAreas = [...areas, { id: id, path: [{ x, y }] }]
+    this.drawCanvas()
+  }
+
+  updateFogArea(id, x, y) {
+    const areas = this.fogAreas
+    this.fogAreas = areas.map(area => {
+      if (area.id == id) {
+        area.path = [...area.path, { x, y }]
+      }
+      return area
+    })
+    this.drawCanvas()
+  }
+
+  getFogArea(id) {
+    const areas = this.fogAreas
+    return areas.find(area => area.id == id)
   }
 
   startDrawingFog(event) {
     if(event.shiftKey) {
       event.stopImmediatePropagation()
       const { x: startX, y: startY } = this.mapPositionOf(event)
-      const fogPath = this.addFogArea(uuid(), `M ${startX} ${startY}`)
+      const id = uuid()
+      this.addFogArea(id, startX, startY)
 
       const drawFog = event => {
         event.stopImmediatePropagation()
         const { x, y } = this.mapPositionOf(event)
-        fogPath.setAttribute('d', `${fogPath.getAttribute('d')} L ${x} ${y}`)
+        this.updateFogArea(id, x, y)
       }
+
       document.onmouseup = event => {
         event.stopImmediatePropagation()
-        fogPath.setAttribute('d', `${fogPath.getAttribute('d')} Z`)
         this.channel.perform(
           "reveal_area",
           {
             map_id: this.mapId,
-            id: fogPath.dataset.id,
-            path: fogPath.getAttribute("d")
+            id: id,
+            path: JSON.stringify(this.getFogArea(id).path)
           }
         )
         document.removeEventListener("mousemove", drawFog)
@@ -76,5 +128,13 @@ export default class extends Controller {
       }
       document.addEventListener("mousemove", drawFog)
     }
+  }
+
+  get fogAreas() {
+    return JSON.parse(this.canvasTarget.dataset["map-FogAreas"])
+  }
+
+  set fogAreas(areas) {
+    this.canvasTarget.dataset["map-FogAreas"] = JSON.stringify(areas)
   }
 }

--- a/app/javascript/src/components/_fog.scss
+++ b/app/javascript/src/components/_fog.scss
@@ -16,6 +16,10 @@ $mask-dm-opacity: 0.5;
   width: calc(var(--original-width) * 1px);
 }
 
+.fog--dm {
+  opacity: $mask-dm-opacity;
+}
+
 .fog__layer {
   fill: $mask-color;
   mask: url("#fogMask");

--- a/app/models/fog_area.rb
+++ b/app/models/fog_area.rb
@@ -1,8 +1,6 @@
 class FogArea < ApplicationRecord
-  BASIC_SVG_PATH = /M (?:-?\d+ ){2}(?:L (?:-?\d+ ){2})*Z/.freeze
-
   belongs_to :map
 
   validates :map, presence: true
-  validates :path, presence: true, format: { with: BASIC_SVG_PATH }
+  validates :path, presence: true
 end

--- a/app/views/campaigns/_current_map.html.erb
+++ b/app/views/campaigns/_current_map.html.erb
@@ -44,16 +44,7 @@
       </div>
 
       <% if campaign.current_map.fog_enabled? %>
-        <%= content_tag :svg, xmlns: "http://www.w3.org/2000/svg", class: "fog", viewBox: "0 0 #{campaign.current_map.scaled_width} #{campaign.current_map.scaled_height}" do %>
-          <defs>
-            <mask data-target="map--fog.fogMask" id="fogMask">
-              <rect class="fog__mask-base-layer" />
-              <%= render campaign.current_map.fog_areas %>
-            </mask>
-          </defs>
-
-          <%= content_tag :rect, "", width: campaign.current_map.scaled_width, height: campaign.current_map.scaled_height, class: "fog__layer #{"fog__layer--dm" if admin}" %>
-        <% end %>
+        <%= content_tag :canvas, "", width: campaign.current_map.scaled_width, height: campaign.current_map.scaled_height, class: "absolute fog #{"fog--dm" if admin}", data: { target: "map--fog.canvas", "map--fog-areas": serialize_fog_areas(campaign.current_map.fog_areas) } %>
       <% end %>
 
       <div class="current-map__map-name">

--- a/db/migrate/20200711183641_convert_fog_path_format_to_array.rb
+++ b/db/migrate/20200711183641_convert_fog_path_format_to_array.rb
@@ -1,0 +1,32 @@
+class ConvertFogPathFormatToArray < ActiveRecord::Migration[6.0]
+  def up
+    FogArea.find_each do |fog_area|
+      segments = fog_area.path.split(" ").reduce([]) do |items, value|
+        if ("a".."z").cover?(value.downcase)
+          items << [value]
+        else
+          items[-1] << value
+        end
+        items
+      end
+
+      json_path = segments.map do |segment|
+        next if segment[0].casecmp("z").zero?
+
+        { x: segment[1].to_i, y: segment[2].to_i }
+      end.compact.to_json
+
+      fog_area.update_attribute(:path, json_path)
+    end
+  end
+
+  def down
+    FogArea.find_each do |fog_area|
+      svg_path = JSON.parse(fog_area.path).map.with_index do |segment, index|
+        "#{index.zero? ? 'M' : 'L'} #{segment['x']} #{segment['y']}"
+      end.join(" ") + " Z"
+
+      fog_area.update_attribute(:path, svg_path)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_06_092613) do
+ActiveRecord::Schema.define(version: 2020_07_11_183641) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
   factory :fog_area do
     map
     id { SecureRandom.uuid } # For attributes_for calls as declared by JS
-    path { "M 10 10 L 10 90 L 90 90 L 90 10 Z" }
+    path { [{ x: 10, y: 10 }].to_json }
   end
 
   factory :map do

--- a/spec/models/fog_area_spec.rb
+++ b/spec/models/fog_area_spec.rb
@@ -8,7 +8,5 @@ RSpec.describe FogArea, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of :map }
     it { is_expected.to validate_presence_of :path }
-    it { is_expected.to allow_value("M -10 10 L 8 400 Z").for(:path) }
-    it { is_expected.not_to allow_value("horses").for(:path) }
   end
 end


### PR DESCRIPTION
Performance with SVG was very poor. Drawing it with canvas seems better.

Changes the `FogArea` paths to JSON representations rather than the SVG path format.