### PR TITLE
Fix map position breaking on pointer and token actions

### DIFF
--- a/app/channels/map_channel.rb
+++ b/app/channels/map_channel.rb
@@ -17,32 +17,4 @@ class MapChannel < ApplicationCable::Channel
 
     map.update(zoom: data["zoom"])
   end
-
-  def point_to(data)
-    map = Map.find(data["map_id"])
-    pointer = Pointer.new(map: map, x: data["x"], y: data["y"])
-
-    MapChannel.add_pointer(pointer)
-  end
-
-  class << self
-    def add_pointer(pointer)
-      broadcast_to(
-        pointer.map,
-        {
-          operation: "addPointer",
-          pointer_html: render_pointer(pointer)
-        }
-      )
-    end
-
-    private
-
-    def render_pointer(pointer)
-      ApplicationController.renderer.render(
-        partial: "pointers/pointer",
-        locals: { pointer: pointer }
-      )
-    end
-  end
 end

--- a/app/channels/maps/pointers_channel.rb
+++ b/app/channels/maps/pointers_channel.rb
@@ -1,0 +1,36 @@
+module Maps
+  class PointersChannel < ApplicationCable::Channel
+    def subscribed
+      map = Map.find(params[:id])
+      stream_for map
+    end
+
+    def point_to(data)
+      map = Map.find(data["map_id"])
+      pointer = Pointer.new(map: map, x: data["x"], y: data["y"])
+
+      Maps::PointersChannel.add_pointer(pointer)
+    end
+
+    class << self
+      def add_pointer(pointer)
+        broadcast_to(
+          pointer.map,
+          {
+            operation: "addPointer",
+            pointer_html: render_pointer(pointer)
+          }
+        )
+      end
+
+      private
+
+      def render_pointer(pointer)
+        ApplicationController.renderer.render(
+          partial: "pointers/pointer",
+          locals: { pointer: pointer }
+        )
+      end
+    end
+  end
+end

--- a/app/channels/maps/tokens_channel.rb
+++ b/app/channels/maps/tokens_channel.rb
@@ -1,0 +1,62 @@
+module Maps
+  class TokensChannel < ApplicationCable::Channel
+    def subscribed
+      map = Map.find(params[:id])
+      stream_for map
+    end
+
+    def stash_token(data)
+      map = Map.find(data["map_id"])
+      token = map.tokens.find(data["token_id"])
+      return if !dm?(map.campaign)
+
+      token.update(stashed: true)
+      broadcast_to(
+        map,
+        {
+          operation: "stashToken",
+          token_id: token.id,
+          stashed: true
+        }
+      )
+    end
+
+    def place_token(data)
+      map = Map.find(data["map_id"])
+      token = map.tokens.find(data["token_id"])
+      return if !dm?(map.campaign)
+
+      if token.copy_on_place?
+        map.copy_token(token)
+      else
+        token.update(stashed: false)
+        Maps::TokensChannel.add_token(token)
+      end
+    end
+
+    class << self
+      def add_token(token)
+        broadcast_to(
+          token.map,
+          {
+            operation: "addToken",
+            token_id: token.id,
+            token_html: render_token(token),
+            x: token.x,
+            y: token.y,
+            stashed: token.stashed
+          }
+        )
+      end
+
+      private
+
+      def render_token(token)
+        ApplicationController.renderer.render(
+          partial: "tokens/token",
+          locals: { token: token }
+        )
+      end
+    end
+  end
+end

--- a/app/javascript/controllers/map/pointers_controller.js
+++ b/app/javascript/controllers/map/pointers_controller.js
@@ -1,0 +1,53 @@
+import { Controller } from "stimulus"
+import consumer from "../../channels/consumer"
+
+export default class extends Controller {
+  static targets = ["container", "image"]
+
+  connect() {
+    this.mapId = this.element.dataset.mapId
+
+    this.channel = consumer.subscriptions.create({
+      channel: "Maps::PointersChannel",
+      id: this.mapId
+    }, {
+      received: this.cableReceived.bind(this)
+    })
+  }
+
+  cableReceived(data) {
+    switch (data.operation) {
+      case "addPointer": {
+        this.containerTarget.insertAdjacentHTML("beforeend", data.pointer_html)
+        break;
+      }
+    }
+  }
+
+  pointTo(event) {
+    if (event.altKey) {
+      event.preventDefault()
+      event.stopPropagation()
+
+      const { x, y } = this.mapPositionOf(event)
+
+      this.channel.perform(
+        "point_to",
+        {
+          map_id: this.mapId,
+          x, y
+        }
+      )
+    }
+  }
+
+  mapPositionOf(event) {
+    const { clientX, clientY } = event
+    const { viewportX, viewportY, x: mapX, y: mapY, zoomAmount } = this.imageTarget.dataset
+    const { left: imageLeft, top: imageTop } = this.imageTarget.getBoundingClientRect()
+
+    const x = Math.round((clientX - imageLeft) / parseFloat(zoomAmount) - (((parseFloat(viewportX) / 2)) / parseFloat(zoomAmount)) + parseFloat(mapX))
+    const y = Math.round((clientY - imageTop) / parseFloat(zoomAmount) - (((parseFloat(viewportY) / 2)) / parseFloat(zoomAmount)) + parseFloat(mapY))
+    return { x, y }
+  }
+}

--- a/app/javascript/controllers/map/tokens_controller.js
+++ b/app/javascript/controllers/map/tokens_controller.js
@@ -1,0 +1,174 @@
+import { Controller } from "stimulus"
+import consumer from "../../channels/consumer"
+
+export default class extends Controller {
+  static targets = ["container", "drawer", "token", "image"]
+
+  connect() {
+    this.mapId = this.element.dataset.mapId
+
+    this.tokenTargets.forEach(target => {
+      target.ondragstart = () => null
+    })
+
+    this.channel = consumer.subscriptions.create({
+      channel: "Maps::TokensChannel",
+      id: this.mapId
+    }, {
+      received: this.cableReceived.bind(this)
+    })
+  }
+
+  cableReceived(data) {
+    switch (data.operation) {
+      case "addToken": {
+        if (this.findToken(data.token_id)) {
+          return
+        }
+        this.containerTarget.insertAdjacentHTML("beforeend", data.token_html);
+        const token = this.findToken(data.token_id)
+        if (data.stashed) {
+          if (this.hasDrawerTarget) {
+            this.drawerTarget.appendChild(token)
+          } else {
+            token.remove()
+          }
+        }
+        break;
+      }
+      case "stashToken": {
+        const token = this.findToken(data.token_id)
+        if (this.hasDrawerTarget) {
+          this.drawerTarget.appendChild(token)
+        } else {
+          token.remove()
+        }
+        break
+      }
+    }
+  }
+
+  startMoveToken(event) {
+    event.stopPropagation()
+
+    const { target, clientX, clientY } = event
+    this.recordPointerLocation(event.clientX, event.clientY)
+    const { left, top } = target.getBoundingClientRect()
+
+    const tokenImage = target.getElementsByClassName("token__image")[0]
+    const { width: tokenWidth, height: tokenHeight } = tokenImage.getBoundingClientRect()
+
+    target.dataset.beingDragged = true
+    target.dataset.offsetX = (tokenWidth / 2) - (clientX - left)
+    target.dataset.offsetY = (tokenHeight / 2) - (clientY - top)
+
+    event.dataTransfer.setData("text/plain", target.dataset.tokenId)
+  }
+
+  moveToken(event) {
+    event.stopPropagation()
+
+    const { target } = event
+    const { x: currentX, y: currentY, offsetX, offsetY } = target.dataset
+    const { zoomAmount } = this.imageTarget.dataset
+    const { x, y } = this.mapPositionOf(
+      new MouseEvent("drag", {
+        clientX: this.element.dataset.clientX,
+        clientY: this.element.dataset.clientY
+      })
+    )
+
+    const newX = Math.floor(x + (parseFloat(offsetX) / parseFloat(zoomAmount)))
+    const newY = Math.floor(y + (parseFloat(offsetY) / parseFloat(zoomAmount)))
+
+    if (newX != currentX || newY != currentY) {
+      this.setTokenLocation(
+        target,
+        newX,
+        newY
+      )
+    }
+  }
+
+  endMoveToken({ target }) {
+    delete target.dataset.beingDragged
+    delete target.dataset.offsetX
+    delete target.dataset.offsetY
+  }
+
+  setTokenLocation(token, x, y) {
+    token.dataset.x = x
+    token.dataset.y = y
+  }
+
+  recordPointerLocation(clientX, clientY) {
+    this.element.dataset.clientX = clientX
+    this.element.dataset.clientY = clientY
+  }
+
+  dragOver(event) {
+    this.recordPointerLocation(event.clientX, event.clientY)
+  }
+
+  dragOverDrawer(event) {
+    event.preventDefault()
+  }
+
+  dropOnDrawer(event) {
+    event.preventDefault()
+    const tokenId = event.dataTransfer.getData("text/plain")
+
+    const token = this.findToken(tokenId)
+    this.drawerTarget.appendChild(token)
+
+    this.channel.perform(
+      "stash_token",
+      {
+        map_id: this.mapId,
+        token_id: tokenId
+      }
+    )
+  }
+
+  dragOverMap(event) {
+    event.preventDefault()
+  }
+
+  dropOnMap(event) {
+    event.preventDefault()
+    const tokenId = event.dataTransfer.getData("text/plain")
+
+    const token = this.findToken(tokenId)
+    if (token.parentNode != this.containerTarget) {
+      if (token.dataset.copyOnPlace != "true") {
+        this.containerTarget.appendChild(token)
+      }
+
+      this.channel.perform(
+        "place_token",
+        {
+          map_id: this.mapId,
+          token_id: tokenId
+        }
+      )
+    }
+  }
+
+  findToken(tokenId) {
+    return this.tokenTargets.find(token => token.dataset.tokenId == tokenId)
+  }
+
+  mapPositionOf(event) {
+    const { clientX, clientY } = event
+    const { viewportX, viewportY, x: mapX, y: mapY, zoomAmount } = this.imageTarget.dataset
+    const { left: imageLeft, top: imageTop } = this.imageTarget.getBoundingClientRect()
+
+    const x = Math.round((clientX - imageLeft) / parseFloat(zoomAmount) - (((parseFloat(viewportX) / 2)) / parseFloat(zoomAmount)) + parseFloat(mapX))
+    const y = Math.round((clientY - imageTop) / parseFloat(zoomAmount) - (((parseFloat(viewportY) / 2)) / parseFloat(zoomAmount)) + parseFloat(mapY))
+    return { x, y }
+  }
+
+  stopPropagation(event) {
+    event.stopPropagation()
+  }
+}

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -2,19 +2,14 @@ import { Controller } from "stimulus"
 import consumer from "../channels/consumer"
 
 export default class extends Controller {
-  static targets = ["image", "zoomIn", "zoomOut", "token", "tokenContainer", "tokenDrawer", "fogMask", "fogArea"]
+  static targets = ["image", "zoomIn", "zoomOut", "fogMask", "fogArea", "tokenContainer"]
 
   connect() {
     this.mapId = this.element.dataset.mapId
-    this.operatorCode = this.generateOperatorCode()
     this.zoomAmounts = this.imageTarget.dataset.zoomAmounts.split(",").map(parseFloat)
 
     this.setViewportSize()
     this.updateZoomButtons()
-
-    this.tokenTargets.forEach(target => {
-      target.ondragstart = () => null
-    })
 
     this.channel = consumer.subscriptions.create({
       channel: "MapChannel",
@@ -131,67 +126,6 @@ export default class extends Controller {
     )
   }
 
-  stopPropagation(event) {
-    event.stopPropagation()
-  }
-
-  dragOver(event) {
-    this.recordPointerLocation(event.clientX, event.clientY)
-  }
-
-  recordPointerLocation(clientX, clientY) {
-    this.element.dataset.clientX = clientX
-    this.element.dataset.clientY = clientY
-  }
-
-  startMoveToken(event) {
-    event.stopPropagation()
-
-    const { target, clientX, clientY } = event
-    this.recordPointerLocation(event.clientX, event.clientY)
-    const { left, top } = target.getBoundingClientRect()
-
-    const tokenImage = target.getElementsByClassName("token__image")[0]
-    const { width: tokenWidth, height: tokenHeight } = tokenImage.getBoundingClientRect()
-
-    target.dataset.beingDragged = true
-    target.dataset.offsetX = (tokenWidth / 2) - (clientX - left)
-    target.dataset.offsetY = (tokenHeight / 2) - (clientY - top)
-
-    event.dataTransfer.setData("text/plain", target.dataset.tokenId)
-  }
-
-  moveToken(event) {
-    event.stopPropagation()
-
-    const { target } = event
-    const { x: currentX, y: currentY, offsetX, offsetY, tokenId } = target.dataset
-    const { zoomAmount } = this.imageTarget.dataset
-    const { x, y } = this.mapPositionOf(
-      new MouseEvent("drag", {
-        clientX: this.element.dataset.clientX,
-        clientY: this.element.dataset.clientY
-      })
-    )
-
-    const newX = Math.floor(x + (parseFloat(offsetX) / parseFloat(zoomAmount)))
-    const newY = Math.floor(y + (parseFloat(offsetY) / parseFloat(zoomAmount)))
-
-    if (newX != currentX || newY != currentY) {
-      this.setTokenLocation(
-        target,
-        newX,
-        newY
-      )
-    }
-  }
-
-  endMoveToken({ target }) {
-    delete target.dataset.beingDragged
-    delete target.dataset.offsetX
-    delete target.dataset.offsetY
-  }
-
   updateZoomButtons() {
     if (this.hasZoomOutTarget && this.hasZoomInTarget) {
       const zoom = parseInt(this.imageTarget.dataset.zoom)
@@ -202,93 +136,10 @@ export default class extends Controller {
 
   cableReceived(data) {
     switch (data.operation) {
-      case "addToken": {
-        if (this.findToken(data.token_id)) {
-          return
-        }
-        this.tokenContainerTarget.insertAdjacentHTML("beforeend", data.token_html);
-        const token = this.findToken(data.token_id)
-        if (data.stashed) {
-          if (this.hasTokenDrawerTarget) {
-            this.tokenDrawerTarget.appendChild(token)
-          } else {
-            token.remove()
-          }
-        }
-        break;
-      }
       case "addPointer": {
         this.tokenContainerTarget.insertAdjacentHTML("beforeend", data.pointer_html)
         break;
       }
-      case "stashToken": {
-        const token = this.findToken(data.token_id)
-        if (this.hasTokenDrawerTarget) {
-          this.tokenDrawerTarget.appendChild(token)
-        } else {
-          token.remove()
-        }
-        break
-      }
     }
-  }
-
-  findToken(tokenId) {
-    return this.tokenTargets.find(token => token.dataset.tokenId == tokenId)
-  }
-
-  setTokenLocation(token, x, y) {
-    token.dataset.x = x
-    token.dataset.y = y
-  }
-
-  dragOverDrawer(event) {
-    event.preventDefault()
-  }
-
-  dropOnDrawer(event) {
-    event.preventDefault()
-    const tokenId = event.dataTransfer.getData("text/plain")
-
-    const token = this.findToken(tokenId)
-    this.tokenDrawerTarget.appendChild(token)
-
-    this.channel.perform(
-      "stash_token",
-      {
-        map_id: this.mapId,
-        token_id: tokenId
-      }
-    )
-  }
-
-  dragOverMap(event) {
-    event.preventDefault()
-  }
-
-  dropOnMap(event) {
-    event.preventDefault()
-    const tokenId = event.dataTransfer.getData("text/plain")
-
-    const token = this.findToken(tokenId)
-    if (token.parentNode != this.tokenContainerTarget) {
-      if (token.dataset.copyOnPlace != "true") {
-        this.tokenContainerTarget.appendChild(token)
-      }
-
-      this.channel.perform(
-        "place_token",
-        {
-          map_id: this.mapId,
-          token_id: tokenId
-        }
-      )
-    }
-  }
-
-  generateOperatorCode() {
-    return Array
-      .from(window.crypto.getRandomValues(new Uint8Array(32)))
-      .map(c => (c < 16 ? "0" : "") + c.toString(16)).join([]);
   }
 }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "stimulus"
 import consumer from "../channels/consumer"
 
 export default class extends Controller {
-  static targets = ["image", "zoomIn", "zoomOut", "fogMask", "fogArea", "tokenContainer"]
+  static targets = ["image", "zoomIn", "zoomOut"]
 
   connect() {
     this.mapId = this.element.dataset.mapId
@@ -14,8 +14,6 @@ export default class extends Controller {
     this.channel = consumer.subscriptions.create({
       channel: "MapChannel",
       id: this.mapId
-    }, {
-      received: this.cableReceived.bind(this)
     })
 
     this.onWindowResize = this.setViewportSize.bind(this)
@@ -34,23 +32,6 @@ export default class extends Controller {
     const x = Math.round((clientX - imageLeft) / parseFloat(zoomAmount) - (((parseFloat(viewportX) / 2)) / parseFloat(zoomAmount)) + parseFloat(mapX))
     const y = Math.round((clientY - imageTop) / parseFloat(zoomAmount) - (((parseFloat(viewportY) / 2)) / parseFloat(zoomAmount)) + parseFloat(mapY))
     return { x, y }
-  }
-
-  pointTo(event) {
-    if (event.altKey) {
-      event.preventDefault()
-      event.stopPropagation()
-
-      const { x, y } = this.mapPositionOf(event)
-
-      this.channel.perform(
-        "point_to",
-        {
-          map_id: this.mapId,
-          x, y
-        }
-      )
-    }
   }
 
   moveMap(event) {
@@ -131,15 +112,6 @@ export default class extends Controller {
       const zoom = parseInt(this.imageTarget.dataset.zoom)
       this.zoomOutTarget.disabled = (zoom === 0)
       this.zoomInTarget.disabled = (zoom === parseInt(this.imageTarget.dataset.zoomMax))
-    }
-  }
-
-  cableReceived(data) {
-    switch (data.operation) {
-      case "addPointer": {
-        this.tokenContainerTarget.insertAdjacentHTML("beforeend", data.pointer_html)
-        break;
-      }
     }
   }
 }

--- a/app/javascript/controllers/sync_values_controller.js
+++ b/app/javascript/controllers/sync_values_controller.js
@@ -24,6 +24,10 @@ export default class extends Controller {
     this.disconnectObserver()
 
     this.syncedVariables.forEach(variable => {
+      if (data[variable] == undefined) {
+        return
+      }
+
       this.element.dataset[variable] = data[variable]
     })
 

--- a/app/jobs/token_broadcast_job.rb
+++ b/app/jobs/token_broadcast_job.rb
@@ -2,6 +2,6 @@ class TokenBroadcastJob < ApplicationJob
   queue_as :default
 
   def perform(token)
-    MapChannel.add_token(token)
+    Maps::TokensChannel.add_token(token)
   end
 end

--- a/app/views/campaigns/_current_map.html.erb
+++ b/app/views/campaigns/_current_map.html.erb
@@ -2,7 +2,7 @@
   <%= content_tag :div,
     class: "flex-1 flex flex-row h-full",
     data: {
-      controller: "map map--tokens #{"map--fog" if campaign.current_map.fog_enabled?}",
+      controller: "map map--tokens map--pointers #{"map--fog" if campaign.current_map.fog_enabled?}",
       "map-id": campaign.current_map.id,
       action: "dragover->map--tokens#dragOver"
     } do %>
@@ -20,8 +20,8 @@
       data: {
         controller: "css-var #{"sync-values" if admin}",
         "map-id": campaign.current_map.id,
-        target: "map.image map--tokens.image #{"map--fog.image" if campaign.current_map.fog_enabled?}",
-        action: "dragover->map--tokens#dragOverMap drop->map--tokens#dropOnMap mousedown->map#pointTo #{"mousedown->map--fog#startDrawingFog" if campaign.current_map.fog_enabled? && admin} mousedown->map#moveMap",
+        target: "map.image map--tokens.image map--pointers.image #{"map--fog.image" if campaign.current_map.fog_enabled?}",
+        action: "dragover->map--tokens#dragOverMap drop->map--tokens#dropOnMap mousedown->map--pointers#pointTo #{"mousedown->map--fog#startDrawingFog" if campaign.current_map.fog_enabled? && admin} mousedown->map#moveMap",
         x: campaign.current_map.x,
         y: campaign.current_map.y,
         zoom: campaign.current_map.zoom,
@@ -39,7 +39,7 @@
         "sync-values-keys": "x y"
       } do %>
       <%= content_tag :div, "", class: "current-map__image", style: background_image(campaign.current_map.image) %>
-      <div class="current-map__token-container" data-target="map.tokenContainer map--tokens.container">
+      <div class="current-map__token-container" data-target="map--tokens.container map--pointers.container">
         <%= render campaign.current_map.tokens.where(stashed: false) %>
       </div>
 

--- a/app/views/campaigns/_current_map.html.erb
+++ b/app/views/campaigns/_current_map.html.erb
@@ -2,12 +2,12 @@
   <%= content_tag :div,
     class: "flex-1 flex flex-row h-full",
     data: {
-      controller: "map #{"map--fog" if campaign.current_map.fog_enabled?}",
+      controller: "map map--tokens #{"map--fog" if campaign.current_map.fog_enabled?}",
       "map-id": campaign.current_map.id,
-      action: "dragover->map#dragOver"
+      action: "dragover->map--tokens#dragOver"
     } do %>
     <% if admin %>
-      <div class="current-map__token-drawer token-drawer" data-target="map.tokenDrawer" data-action="dragover->map#dragOverDrawer drop->map#dropOnDrawer">
+      <div class="current-map__token-drawer token-drawer" data-target="map--tokens.drawer" data-action="dragover->map--tokens#dragOverDrawer drop->map--tokens#dropOnDrawer">
         <%= link_to new_campaign_map_token_path(campaign, campaign.current_map), remote: true, title: "New Token", class: "token new-token-link" do %>
           <span class="token__image token__image-add">+</span>
         <% end %>
@@ -20,8 +20,8 @@
       data: {
         controller: "css-var #{"sync-values" if admin}",
         "map-id": campaign.current_map.id,
-        target: "map.image #{"map--fog.image" if campaign.current_map.fog_enabled?}",
-        action: "dragover->map#dragOverMap drop->map#dropOnMap mousedown->map#pointTo #{"mousedown->map--fog#startDrawingFog" if campaign.current_map.fog_enabled? && admin} mousedown->map#moveMap",
+        target: "map.image map--tokens.image #{"map--fog.image" if campaign.current_map.fog_enabled?}",
+        action: "dragover->map--tokens#dragOverMap drop->map--tokens#dropOnMap mousedown->map#pointTo #{"mousedown->map--fog#startDrawingFog" if campaign.current_map.fog_enabled? && admin} mousedown->map#moveMap",
         x: campaign.current_map.x,
         y: campaign.current_map.y,
         zoom: campaign.current_map.zoom,
@@ -39,7 +39,7 @@
         "sync-values-keys": "x y"
       } do %>
       <%= content_tag :div, "", class: "current-map__image", style: background_image(campaign.current_map.image) %>
-      <div class="current-map__token-container" data-target="map.tokenContainer">
+      <div class="current-map__token-container" data-target="map.tokenContainer map--tokens.container">
         <%= render campaign.current_map.tokens.where(stashed: false) %>
       </div>
 

--- a/app/views/tokens/_token.html.erb
+++ b/app/views/tokens/_token.html.erb
@@ -3,8 +3,8 @@
   draggable: true,
   data: {
     controller: "css-var sync-values",
-    target: "map.token",
-    action: "dragstart->map#startMoveToken drag->map#moveToken dragend->map#endMoveToken mousedown->map#stopPropagation",
+    target: "map--tokens.token",
+    action: "dragstart->map--tokens#startMoveToken drag->map--tokens#moveToken dragend->map--tokend#endMoveToken mousedown->map--tokens#stopPropagation",
     token_id: token.id,
     x: token.x,
     y: token.y,

--- a/spec/system/create_tokens_spec.rb
+++ b/spec/system/create_tokens_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "create tokens", type: :system do
     end
 
     # if we don't use find here, capybara doesn't wait for the ajax to complete
-    html_token = find(".token[data-target='map.token']")
+    html_token = find(".token[data-target='map--tokens.token']")
     token = map.reload.tokens.first
     expect(html_token["data-token-id"]).to eq token.id
   end

--- a/spec/system/manage_characters_spec.rb
+++ b/spec/system/manage_characters_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "manage characters", type: :system do
     click_on "Create Character"
 
     # if we don't use find here, capybara doesn't wait for the ajax to complete
-    html_token = find(".token[data-target='map.token']")
+    html_token = find(".token[data-target='map--tokens.token']")
     character = campaign.characters.last
     expect(character.name).to eq "Uxil"
     expect(html_token["data-token-id"]).to eq character.tokens.first.id

--- a/spec/system/manage_creatures_spec.rb
+++ b/spec/system/manage_creatures_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "manage creatures", type: :system do
     click_on "Create Creature"
 
     # if we don't use find here, capybara doesn't wait for the ajax to complete
-    html_token = find(".token[data-target='map.token']")
+    html_token = find(".token[data-target='map--tokens.token']")
     token = campaign.current_map.tokens.last
     expect(html_token["data-token-id"]).to eq token.id
     expect(token.name).to eq "Orc"
@@ -37,14 +37,14 @@ RSpec.describe "manage creatures", type: :system do
     click_on "Create Creature"
 
     drawer_token = find(
-      ".current-map__token-drawer .token[data-target='map.token']"
+      ".current-map__token-drawer .token[data-target='map--tokens.token']"
     )
     expect(drawer_token.native.size.width).to eq base_drawer_size
     expect(drawer_token.native.size.height).to eq base_drawer_size
 
     drawer_token.drag_to(map_element(map), html5: true)
 
-    map_token = find(".current-map .token[data-target='map.token']")
+    map_token = find(".current-map .token[data-target='map--tokens.token']")
     expect(map_token.native.size.width).to eq large_map_size
     expect(map_token.native.size.height).to eq large_map_size
   end


### PR DESCRIPTION
Fixes a bug with the `SyncValuesController` making any values not being updated `undefined`. Also separates map, token and pointer management out across `MapChannel`, `Maps::TokensChannel` and `Maps::PointersChannel`.

The `SyncValuesController` looks at all communication on its give channel and updates any synced values. For the bug in question, the `MapChannel` was receiving events like:

```js
const data = {
  operation: "addToken",
  x: 123,
  y: 456
}
```

The `SyncValuesController` would ignore the `operation` value and just update the map's `x` and `y` to the provided values (where the token should be placed).

To address this, the token and pointer operations have been extracted to separate channels and will no longer collide with the `SyncValuesController`.