### PR TITLE
Toggle token drawer

### DIFF
--- a/app/assets/images/icons/tokens.svg
+++ b/app/assets/images/icons/tokens.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+<defs><style>.a{fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;}</style></defs>
+<path class="a" d="M6.831,17.435a34.3,34.3,0,0,1,3.25-1.293c.608-.226.509-1.815.239-2.111A4.49,4.49,0,0,1,9.151,10.55,2.934,2.934,0,0,1,12,7.335a2.934,2.934,0,0,1,2.849,3.215,4.49,4.49,0,0,1-1.169,3.481c-.27.3-.369,1.885.239,2.111a34.3,34.3,0,0,1,3.25,1.293"/>
+<circle class="a" cx="12" cy="12" r="10"/>
+</svg>

--- a/app/javascript/controllers/map/tokens_controller.js
+++ b/app/javascript/controllers/map/tokens_controller.js
@@ -50,6 +50,9 @@ export default class extends Controller {
 
   startMoveToken(event) {
     event.stopPropagation()
+    if (this.hasDrawerTarget) {
+      this.drawerTarget.dispatchEvent(new CustomEvent('open'))
+    }
 
     const { target, clientX, clientY } = event
     this.recordPointerLocation(event.clientX, event.clientY)
@@ -111,7 +114,21 @@ export default class extends Controller {
   }
 
   dragOverDrawer(event) {
+    event.stopPropagation()
     event.preventDefault()
+    var dragging = this.tokenTargets.find(token => token.dataset.beingDragged)
+    if (dragging && dragging.parentNode != this.drawerTarget) {
+      this.drawerTarget.appendChild(dragging)
+    }
+  }
+
+  dragOverToken(event) {
+    event.stopPropagation()
+    var draggedOver = event.target
+    var dragging = this.tokenTargets.find(token => token.dataset.beingDragged)
+    if (this.hasDrawerTarget && draggedOver.parentNode == this.drawerTarget && dragging) {
+      this.drawerTarget.insertBefore(dragging, draggedOver)
+    }
   }
 
   dropOnDrawer(event) {
@@ -119,7 +136,10 @@ export default class extends Controller {
     const tokenId = event.dataTransfer.getData("text/plain")
 
     const token = this.findToken(tokenId)
-    this.drawerTarget.appendChild(token)
+    if (token.parentNode != this.drawerTarget) {
+      this.drawerTarget.appendChild(token)
+    }
+    this.drawerTarget.dispatchEvent(new CustomEvent('close'))
 
     this.channel.perform(
       "stash_token",
@@ -139,6 +159,9 @@ export default class extends Controller {
     const tokenId = event.dataTransfer.getData("text/plain")
 
     const token = this.findToken(tokenId)
+    if (this.hasDrawerTarget) {
+      this.drawerTarget.dispatchEvent(new CustomEvent('close'))
+    }
     if (token.parentNode != this.containerTarget) {
       if (token.dataset.copyOnPlace != "true") {
         this.containerTarget.appendChild(token)

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -4,12 +4,24 @@ export default class extends Controller {
   static targets = ["content"]
 
   toggle(event) {
-    var toggleTarget = event.currentTarget.dataset["toggle-target"]
+    this.perform(event, "toggle")
+  }
+
+  open(event) {
+    this.perform(event, "add")
+  }
+
+  close(event) {
+    this.perform(event, "remove")
+  }
+
+  perform(event, operation) {
+    var toggleTarget = event.currentTarget.dataset.toggleTarget
     var toggleClass = this.data.get("class")
 
     this.contentTargets.forEach((t) => {
-      if (t.dataset["toggle-target"] == toggleTarget) {
-        t.classList.toggle(toggleClass)
+      if (t.dataset.toggleTarget == toggleTarget) {
+        t.classList[operation](toggleClass)
       }
     })
   }

--- a/app/javascript/src/components/_map.scss
+++ b/app/javascript/src/components/_map.scss
@@ -37,16 +37,26 @@
 }
 
 .current-map__token-drawer {
-  @apply
-    bg-gray-500
-  ;
+  @apply absolute;
 
   --drawer-scale: 1.25;
+  left: 1rem;
+  right: 0;
+  top: 3rem;
+  transform: scale(0);
+  transform-origin: top left;
+  transition: all 0.2s ease-in-out;
+  z-index: 40;
+
+  &.show {
+    transform: scale(1);
+  }
 
   .token {
     @apply
       static
       m-2
+      flex-initial
     ;
 
     .token__image {

--- a/app/javascript/src/components/_token.scss
+++ b/app/javascript/src/components/_token.scss
@@ -6,7 +6,9 @@
   @apply
     flex
     items-center
-    absolute;
+    absolute
+    z-50
+  ;
 
   --base-border: 2px;
   --base-size: 40px;

--- a/app/views/campaigns/_current_map.html.erb
+++ b/app/views/campaigns/_current_map.html.erb
@@ -7,13 +7,7 @@
       action: "dragover->map--tokens#dragOver"
     } do %>
     <% if admin %>
-      <div class="current-map__token-drawer token-drawer select-none" data-target="map--tokens.drawer" data-action="dragover->map--tokens#dragOverDrawer drop->map--tokens#dropOnDrawer">
-        <%= link_to new_campaign_map_token_path(campaign, campaign.current_map), remote: true, title: "New Token", class: "token new-token-link" do %>
-          <span class="token__image token__image-add">+</span>
-        <% end %>
-
-        <%= render campaign.current_map.tokens.where(stashed: true) %>
-      </div>
+      <%= render "maps/token_drawer", map: campaign.current_map %>
     <% end %>
     <%= content_tag :div,
       class: "current-map relative overflow-hidden",
@@ -49,6 +43,9 @@
 
       <div class="controls relative z-50 flex h-6 items-stretch m-2">
         <% if admin %>
+          <%= button_tag class: "flex-initial block rounded-md border mr-1 px-2 text-sm bg-gray-200 hover:bg-gray-400 active:bg-gray-600 relative", data: { action: "toggle#toggle", "toggle-target": "token-drawer" }, title: "Tokens" do %>
+            <%= inline_svg_tag "icons/tokens.svg", class: "block fill-current h-full text-black" %>
+          <% end %>
           <%= render "campaigns/map_selector_button" %>
         <% end %>
         <div class="flex-initial rounded-md bg-gray-200 border px-2 text-sm">

--- a/app/views/maps/_token_drawer.html.erb
+++ b/app/views/maps/_token_drawer.html.erb
@@ -1,0 +1,7 @@
+<div class="current-map__token-drawer token-drawer flex flex-row items-center justify-start select-none bg-gray-500 mx-4 p-2 rounded-lg border whitespace-no-wrap overflow-x-auto overflow-y-hidden shadow-lg" data-target="map--tokens.drawer toggle.content" data-action="dragover->map--tokens#dragOverDrawer drop->map--tokens#dropOnDrawer open->toggle#open close->toggle#close" data-toggle-target="token-drawer">
+  <%= link_to new_campaign_map_token_path(map.campaign, map), remote: true, title: "New Token", class: "token new-token-link" do %>
+    <span class="token__image token__image-add">+</span>
+  <% end %>
+
+  <%= render map.tokens.where(stashed: true) %>
+</div>

--- a/app/views/tokens/_token.html.erb
+++ b/app/views/tokens/_token.html.erb
@@ -4,7 +4,7 @@
   data: {
     controller: "css-var sync-values",
     target: "map--tokens.token",
-    action: "dragstart->map--tokens#startMoveToken drag->map--tokens#moveToken dragend->map--tokend#endMoveToken mousedown->map--tokens#stopPropagation",
+    action: "dragenter->map--tokens#dragOverToken dragstart->map--tokens#startMoveToken drag->map--tokens#moveToken dragend->map--tokens#endMoveToken mousedown->map--tokens#stopPropagation",
     token_id: token.id,
     x: token.x,
     y: token.y,

--- a/spec/support/modal.rb
+++ b/spec/support/modal.rb
@@ -1,0 +1,3 @@
+def modal
+  find("[data-controller=modal]")
+end

--- a/spec/support/mouse.rb
+++ b/spec/support/mouse.rb
@@ -126,10 +126,6 @@ def click_and_move_token(token, by:)
   page.execute_script("delete window.tempDataTransfer")
 end
 
-def token_element(token)
-  find(".token[data-token-id='#{token.id}']")
-end
-
 def dispatch_event(node, element, event)
   node.execute_script("#{element}.dispatchEvent(#{event})")
 end

--- a/spec/support/system_test.rb
+++ b/spec/support/system_test.rb
@@ -1,6 +1,11 @@
 RSpec.configure do |config|
   config.before(:suite, type: :system) do
-    Capybara.disable_animation = ".map-selector,.map-selector.show"
+    Capybara.disable_animation = [
+      ".map-selector",
+      ".map-selector.show",
+      ".current-map__token-drawer",
+      ".current-map__token-drawer.show"
+    ].join(",")
   end
   config.before(:each, type: :system) do
     driven_by :selenium_chrome_headless

--- a/spec/support/token.rb
+++ b/spec/support/token.rb
@@ -1,0 +1,11 @@
+def token_drawer
+  find(".current-map__token-drawer")
+end
+
+def open_token_drawer
+  find("button[title=Tokens]").click
+end
+
+def token_element(token)
+  find(".token[data-token-id='#{token.id}']")
+end

--- a/spec/system/create_tokens_spec.rb
+++ b/spec/system/create_tokens_spec.rb
@@ -10,8 +10,11 @@ RSpec.describe "create tokens", type: :system do
 
     visit campaign_path(map.campaign, as: user)
     wait_for_connection
-    click_on "New Token"
-    within "[data-controller=modal]" do
+    open_token_drawer
+    within token_drawer do
+      click_on "New Token"
+    end
+    within modal do
       fill_in "Name", with: "Olokas"
       attach_file "Image", file_fixture("wizard.jpg")
       click_on "Create"

--- a/spec/system/library_spec.rb
+++ b/spec/system/library_spec.rb
@@ -62,8 +62,8 @@ RSpec.describe "manage creatures", type: :system do
     view_library
     click_on "Add to map"
 
-    expect(find(".current-map__token-drawer"))
-      .to have_token(creature.tokens.first)
+    open_token_drawer
+    expect(token_drawer).to have_token(creature.tokens.first)
   end
 
   it "lists characters" do
@@ -127,8 +127,8 @@ RSpec.describe "manage creatures", type: :system do
     view_library
     click_on "Add to map"
 
-    expect(find(".current-map__token-drawer"))
-      .to have_token(character.tokens.first)
+    open_token_drawer
+    expect(token_drawer).to have_token(character.tokens.first)
   end
 
   def have_character(character)
@@ -142,7 +142,14 @@ RSpec.describe "manage creatures", type: :system do
   def view_library
     wait_for_connection
     page.has_no_css?(".modal__background")
-    click_on "New Token"
-    find("label", text: "Library").click
+    if page.has_no_css?(".current-map__token-drawer.show")
+      open_token_drawer
+    end
+    within token_drawer do
+      click_on "New Token"
+    end
+    within modal do
+      find("label", text: "Library").click
+    end
   end
 end

--- a/spec/system/manage_characters_spec.rb
+++ b/spec/system/manage_characters_spec.rb
@@ -8,11 +8,16 @@ RSpec.describe "manage characters", type: :system do
     campaign.update(current_map: map)
 
     visit campaign_path(campaign, as: user)
-    click_on "New Token"
-    find("label", text: "Character").click
-    fill_in "Name", with: "Uxil"
-    attach_file "Image", file_fixture("thief.jpg")
-    click_on "Create Character"
+    open_token_drawer
+    within token_drawer do
+      click_on "New Token"
+    end
+    within modal do
+      find("label", text: "Character").click
+      fill_in "Name", with: "Uxil"
+      attach_file "Image", file_fixture("thief.jpg")
+      click_on "Create Character"
+    end
 
     # if we don't use find here, capybara doesn't wait for the ajax to complete
     html_token = find(".token[data-target='map--tokens.token']")
@@ -28,9 +33,14 @@ RSpec.describe "manage characters", type: :system do
     campaign.update(current_map: map)
 
     visit campaign_path(campaign, as: user)
-    click_on "New Token"
-    find("label", text: "Character").click
-    click_on "Create Character"
+    open_token_drawer
+    within token_drawer do
+      click_on "New Token"
+    end
+    within modal do
+      find("label", text: "Character").click
+      click_on "Create Character"
+    end
 
     expect(page).to have_content "Name can't be blank"
     expect(page).to have_content "Image can't be blank"
@@ -40,16 +50,15 @@ RSpec.describe "manage characters", type: :system do
     map = create :map
     character = create :character, campaign: map.campaign
     token = create :token, map: map, stashed: true, token_template: character
+
     visit campaign_path(map.campaign, as: map.campaign.user)
     wait_for_connection
     find(".map-selector__option", text: map.name).click
+    open_token_drawer
     token_element = token_element(token)
     token_element.drag_to(map_element(map), html5: true)
-    expect(map_element(map)).to have_token(token)
-    expect(token_drawer_element).not_to have_token(token)
-  end
 
-  def token_drawer_element
-    find(".current-map__token-drawer")
+    expect(map_element(map)).to have_token(token)
+    expect(token_drawer).not_to have_token(token)
   end
 end

--- a/spec/system/manage_creatures_spec.rb
+++ b/spec/system/manage_creatures_spec.rb
@@ -8,10 +8,15 @@ RSpec.describe "manage creatures", type: :system do
     campaign.update(current_map: map)
 
     visit campaign_path(campaign, as: user)
-    click_on "New Token"
-    fill_in "Name", with: "Orc"
-    attach_file "Image", file_fixture("thief.jpg")
-    click_on "Create Creature"
+    open_token_drawer
+    within token_drawer do
+      click_on "New Token"
+    end
+    within modal do
+      fill_in "Name", with: "Orc"
+      attach_file "Image", file_fixture("thief.jpg")
+      click_on "Create Creature"
+    end
 
     # if we don't use find here, capybara doesn't wait for the ajax to complete
     html_token = find(".token[data-target='map--tokens.token']")
@@ -30,11 +35,16 @@ RSpec.describe "manage creatures", type: :system do
     campaign.update(current_map: map)
 
     visit campaign_path(campaign, as: user)
-    click_on "New Token"
-    fill_in "Name", with: "Ogre"
-    select "Large"
-    attach_file "Image", file_fixture("thief.jpg")
-    click_on "Create Creature"
+    open_token_drawer
+    within token_drawer do
+      click_on "New Token"
+    end
+    within modal do
+      fill_in "Name", with: "Ogre"
+      select "Large"
+      attach_file "Image", file_fixture("thief.jpg")
+      click_on "Create Creature"
+    end
 
     drawer_token = find(
       ".current-map__token-drawer .token[data-target='map--tokens.token']"
@@ -57,6 +67,7 @@ RSpec.describe "manage creatures", type: :system do
     visit campaign_path(map.campaign, as: map.campaign.user)
     wait_for_connection
     find(".map-selector__option", text: map.name).click
+    open_token_drawer
     token_element = token_element(token)
     token_element.drag_to(map_element(map), html5: true)
 
@@ -65,10 +76,7 @@ RSpec.describe "manage creatures", type: :system do
       creature.tokens.order(created_at: :asc).last,
       "1"
     )
-    expect(token_drawer_element).to have_token(token)
-  end
-
-  def token_drawer_element
-    find(".current-map__token-drawer")
+    open_token_drawer
+    expect(token_drawer).to have_token(token)
   end
 end

--- a/spec/system/manage_maps_spec.rb
+++ b/spec/system/manage_maps_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe "manage maps", type: :system do
       open_selector_and_switch_to_map("Dwarven Excavation")
 
       token = campaign.maps.first.tokens.first
+      open_token_drawer
       expect(page).to have_token_with_data(token, "token-id", token.id)
     end
   end

--- a/spec/system/token_drawer_spec.rb
+++ b/spec/system/token_drawer_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "token drawer", type: :system do
     token = create :token, map: map, stashed: true
     visit campaign_path(map.campaign, as: map.campaign.user)
     wait_for_connection
+    open_token_drawer
     token_element = token_element(token)
     token_element.drag_to(map_element(map), html5: true)
     expect(map_element(map)).to have_token(token)
@@ -22,6 +23,7 @@ RSpec.describe "token drawer", type: :system do
       wait_for_connection
     end
 
+    open_token_drawer
     token_element = token_element(token)
     token_element.drag_to(map_element(map), html5: true)
 
@@ -36,10 +38,11 @@ RSpec.describe "token drawer", type: :system do
 
     visit campaign_path(map.campaign, as: map.campaign.user)
     wait_for_connection
-
     token_element = token_element(token)
-    token_element.drag_to(token_drawer_element, html5: true)
-    expect(token_drawer_element).to have_token(token)
+    token_element.drag_to(token_drawer, html5: true)
+    open_token_drawer
+
+    expect(token_drawer).to have_token(token)
     expect(map_element(map)).not_to have_token(token)
   end
 
@@ -55,14 +58,10 @@ RSpec.describe "token drawer", type: :system do
     end
 
     token_element = token_element(token)
-    token_element.drag_to(token_drawer_element, html5: true)
+    token_element.drag_to(token_drawer, html5: true)
 
     using_session "other user" do
       expect(page).not_to have_token(token)
     end
-  end
-
-  def token_drawer_element
-    find(".current-map__token-drawer")
   end
 end


### PR DESCRIPTION
Closes #103. The moves the token drawer behind a toolbar button. 

![Drawer Token Open and Drag Out](https://user-images.githubusercontent.com/5015/90987283-c3e98d00-e557-11ea-8b66-ff3a1ec27e16.gif)

The drawer is automatically opened whenever you start to drag a token and closed when you stop.

![Drawer Token Start Drag](https://user-images.githubusercontent.com/5015/90987203-1aa29700-e557-11ea-975a-b9b7aa52b098.gif)

You can drag tokens back into the open drawer.

![Drawer Token Drag In](https://user-images.githubusercontent.com/5015/90987213-2b530d00-e557-11ea-817b-2e300f70a3c5.gif)