### PR TITLE
Don't reveal map boundary

### DIFF
--- a/app/javascript/src/components/_fog.scss
+++ b/app/javascript/src/components/_fog.scss
@@ -35,6 +35,14 @@ $mask-dm-opacity: 0.5;
   width: 100%;
 }
 
+.map--fog {
+  background-color: $mask-color;
+}
+
+.map--fog--dm {
+  background-color: rgba($mask-color, $mask-dm-opacity);
+}
+
 @keyframes reveal {
   from {
     fill-opacity: 0;

--- a/app/views/campaigns/_current_map.html.erb
+++ b/app/views/campaigns/_current_map.html.erb
@@ -1,6 +1,6 @@
 <% if campaign.current_map.present? %>
   <%= content_tag :div,
-    class: "flex-1 flex flex-row h-full",
+    class: "flex-1 flex flex-row h-full #{"map--fog" if campaign.current_map.fog_enabled?} #{"map--fog--dm" if admin && campaign.current_map.fog_enabled?}",
     data: {
       controller: "map map--tokens map--pointers #{"map--fog" if campaign.current_map.fog_enabled?}",
       "map-id": campaign.current_map.id,


### PR DESCRIPTION
Fixes #106. Currently, players can tell where the map ends on maps with fog because the background is white. This fixes the problem by setting the background to match the fog that is shown (for both players and DMs).

The white background is preserved for maps without fog.

I did not add specs for this because it didn't seem worth it, but let me know if you disagree.

Before:

![Screen Shot 2020-08-16 at 5 08 56 PM](https://user-images.githubusercontent.com/5015/90344089-5af89700-dfe4-11ea-861f-a08b3736d654.png)

After:

![Screen Shot 2020-08-16 at 5 12 29 PM](https://user-images.githubusercontent.com/5015/90344093-60ee7800-dfe4-11ea-8c85-dfba034493af.png)
