### PR TITLE
Select Tokens Stash and Delete, Including Keyboard Shortcuts

### DIFF
--- a/app/channels/maps/tokens_channel.rb
+++ b/app/channels/maps/tokens_channel.rb
@@ -34,6 +34,21 @@ module Maps
       end
     end
 
+    def delete_token(data)
+      map = Map.find(data["map_id"])
+      token = map.tokens.find(data["token_id"])
+      return if !dm?(map.campaign)
+
+      token.destroy
+      broadcast_to(
+        map,
+        {
+          operation: "deleteToken",
+          token_id: token.id
+        }
+      )
+    end
+
     class << self
       def add_token(token)
         broadcast_to(

--- a/app/javascript/src/components/_map.scss
+++ b/app/javascript/src/components/_map.scss
@@ -5,12 +5,21 @@
   user-select: none;
 
   .controls {
-    [disabled] {
+    :disabled {
       @apply cursor-not-allowed;
 
       svg {
         @apply text-gray-400;
       }
+    }
+  }
+
+  .action {
+    @apply opacity-100;
+    transition: opacity 0.2s ease-in-out;
+
+    &:disabled {
+      @apply opacity-50;
     }
   }
 }

--- a/app/javascript/src/components/_token.scss
+++ b/app/javascript/src/components/_token.scss
@@ -36,6 +36,10 @@
   border-width: calc(var(--base-border) * var(--size-scale) * var(--zoom-amount));
   height: calc((var(--base-size) * var(--size-scale) * var(--zoom-amount)));
   width: calc((var(--base-size) * var(--size-scale) * var(--zoom-amount)));
+
+  [data-selected] & {
+    @apply border-orange-600;
+  }
 }
 
 .token__image-add {

--- a/app/views/campaigns/_current_map.html.erb
+++ b/app/views/campaigns/_current_map.html.erb
@@ -61,6 +61,17 @@
           <% end %>
         </div>
       </div>
+
+      <% if admin %>
+        <div class="controls absolute bottom-0 right-0 flex items-stetch mb-2 mr-2" data-target="map--tokens.actions">
+          <%= button_tag class: "action flex-initial block rounded-md border mr-1 px-2 text-sm bg-gray-200 hover:bg-gray-400 active:bg-gray-600 relative", data: { target: "map--tokens.action", action: "map--tokens#deleteSelected" }, disabled: true, title: "Delete" do %>
+            Delete
+          <% end %>
+          <%= button_tag class: "action flex-initial block rounded-md border mr-1 px-2 text-sm bg-gray-200 hover:bg-gray-400 active:bg-gray-600 relative", data: { target: "map--tokens.action", action: "map--tokens#stashSelected" }, disabled: true, title: "Stash" do %>
+            Stash
+          <% end %>
+        </div>
+      <% end %>
     <% end %>
   <% end %>
 <% else %>

--- a/app/views/maps/_token_drawer.html.erb
+++ b/app/views/maps/_token_drawer.html.erb
@@ -1,4 +1,4 @@
-<div class="current-map__token-drawer token-drawer flex flex-row items-center justify-start select-none bg-gray-500 mx-4 p-2 rounded-lg border whitespace-no-wrap overflow-x-auto overflow-y-hidden shadow-lg" data-target="map--tokens.drawer toggle.content" data-action="dragover->map--tokens#dragOverDrawer drop->map--tokens#dropOnDrawer open->toggle#open close->toggle#close" data-toggle-target="token-drawer">
+<div class="current-map__token-drawer token-drawer flex flex-row items-center justify-start select-none bg-gray-500 mx-4 p-2 rounded-lg border whitespace-no-wrap overflow-x-auto overflow-y-hidden shadow-lg" data-target="map--tokens.drawer toggle.content" data-action="dragover->map--tokens#dragOverDrawer drop->map--tokens#dropOnDrawer toggle->toggle#toggle open->toggle#open close->toggle#close" data-toggle-target="token-drawer">
   <%= link_to new_campaign_map_token_path(map.campaign, map), remote: true, title: "New Token", class: "token new-token-link" do %>
     <span class="token__image token__image-add">+</span>
   <% end %>

--- a/app/views/tokens/_token.html.erb
+++ b/app/views/tokens/_token.html.erb
@@ -4,7 +4,7 @@
   data: {
     controller: "css-var sync-values",
     target: "map--tokens.token",
-    action: "dragenter->map--tokens#dragOverToken dragstart->map--tokens#startMoveToken drag->map--tokens#moveToken dragend->map--tokens#endMoveToken mousedown->map--tokens#stopPropagation",
+    action: "dragenter->map--tokens#dragOverToken dragstart->map--tokens#startMoveToken drag->map--tokens#moveToken dragend->map--tokens#endMoveToken click->map--tokens#toggleTokenSelect mousedown->map--tokens#stopPropagation",
     token_id: token.id,
     x: token.x,
     y: token.y,

--- a/spec/support/mouse.rb
+++ b/spec/support/mouse.rb
@@ -38,6 +38,17 @@ def shift_click_at(element, x:, y:)
   )
 end
 
+def shift_click(element)
+  dispatch_event(
+    element,
+    "this",
+    mouse_event(
+      "click",
+      shift_key: true
+    )
+  )
+end
+
 def mouse_move_to(x:, y:)
   dispatch_event(
     page,

--- a/spec/system/token_actions_spec.rb
+++ b/spec/system/token_actions_spec.rb
@@ -1,0 +1,238 @@
+require "rails_helper"
+
+RSpec.describe "token actions", type: :system do
+  it "can select multiple tokens" do
+    map = create :map, :current
+    token_one = create :token, map: map, stashed: false
+    token_two = create :token, map: map, stashed: false
+
+    visit campaign_path(map.campaign, as: map.campaign.user)
+    wait_for_connection
+
+    shift_click token_element(token_one)
+    shift_click token_element(token_two)
+
+    expect(token_element(token_one)["data-selected"]).to be_present
+    expect(token_element(token_two)["data-selected"]).to be_present
+  end
+
+  it "can use the keyboard to select tokens" do
+    map = create :map, :current
+    token_one = create :token, map: map, stashed: false
+    token_two = create :token, map: map, stashed: false
+
+    visit campaign_path(map.campaign, as: map.campaign.user)
+    wait_for_connection
+
+    page.find("body").send_keys :right
+    expect(token_element(token_one)["data-selected"]).to be_present
+    expect(token_element(token_two)["data-selected"]).not_to be_present
+
+    page.find("body").send_keys :right
+    expect(token_element(token_one)["data-selected"]).not_to be_present
+    expect(token_element(token_two)["data-selected"]).to be_present
+
+    page.find("body").send_keys :right
+    expect(token_element(token_one)["data-selected"]).to be_present
+    expect(token_element(token_two)["data-selected"]).not_to be_present
+
+    page.find("body").send_keys :left
+    expect(token_element(token_one)["data-selected"]).not_to be_present
+    expect(token_element(token_two)["data-selected"]).to be_present
+  end
+
+  describe "when a token is selected" do
+    it "enables token actions" do
+      map = create :map, :current
+      token = create :token, map: map, stashed: false
+
+      visit campaign_path(map.campaign, as: map.campaign.user)
+      wait_for_connection
+
+      expect_token_actions_disabled
+
+      token_element = token_element(token)
+      token_element.click
+
+      expect_token_actions_enabled
+
+      token_element.click
+
+      expect_token_actions_disabled
+    end
+  end
+
+  describe "stash" do
+    it "moves tokens from the map to the drawer by clicking the button" do
+      map = create :map, :current
+      token = create :token, map: map, stashed: false
+
+      visit campaign_path(map.campaign, as: map.campaign.user)
+      wait_for_connection
+      token_element = token_element(token)
+      token_element.click
+      click_on "Stash"
+      open_token_drawer
+
+      expect(token_drawer).to have_token(token)
+      expect(map_element(map)).not_to have_token(token)
+      expect_token_actions_disabled
+    end
+
+    it "moves tokens from the map to the drawer with the keyboard shortcut" do
+      map = create :map, :current
+      token = create :token, map: map, stashed: false
+
+      visit campaign_path(map.campaign, as: map.campaign.user)
+      wait_for_connection
+      token_element = token_element(token)
+      token_element.click
+      page.find("body").send_keys "s"
+      open_token_drawer
+
+      expect(token_drawer).to have_token(token)
+      expect(map_element(map)).not_to have_token(token)
+      expect_token_actions_disabled
+    end
+
+    it "moves multiple tokens from the map to the drawer" do
+      map = create :map, :current
+      token_one = create :token, map: map, stashed: false
+      token_two = create :token, map: map, stashed: false
+
+      visit campaign_path(map.campaign, as: map.campaign.user)
+      wait_for_connection
+      shift_click token_element(token_one)
+      shift_click token_element(token_two)
+      click_on "Stash"
+      open_token_drawer
+
+      expect(token_drawer).to have_token(token_one)
+      expect(token_drawer).to have_token(token_two)
+      expect(map_element(map)).not_to have_token(token_one)
+      expect(map_element(map)).not_to have_token(token_two)
+      expect_token_actions_disabled
+    end
+
+    it "hides the token for other users" do
+      map = create :map, :current
+      token = create :token, map: map, stashed: false
+
+      visit campaign_path(map.campaign, as: map.campaign.user)
+      wait_for_connection
+      using_session "other user" do
+        visit campaign_path(map.campaign)
+        wait_for_connection
+      end
+
+      token_element = token_element(token)
+      token_element.click
+      click_on "Stash"
+
+      using_session "other user" do
+        expect(page).not_to have_css(
+          ".token[data-token-id='#{token.to_param}']"
+        )
+      end
+    end
+  end
+
+  describe "delete" do
+    it "deletes the token from the map by clicking the button" do
+      map = create :map, :current
+      token = create :token, map: map, stashed: false
+
+      visit campaign_path(map.campaign, as: map.campaign.user)
+      wait_for_connection
+      token_element = token_element(token)
+      token_element.click
+      accept_confirm do
+        click_on "Delete"
+      end
+      open_token_drawer
+
+      expect(token_drawer).not_to have_token(token)
+      expect(map_element(map)).not_to have_token(token)
+      expect(Token.exists?(token.id)).not_to be true
+      expect_token_actions_disabled
+    end
+
+    it "deletes the token from the map with the keyboard shortcut" do
+      map = create :map, :current
+      token = create :token, map: map, stashed: false
+
+      visit campaign_path(map.campaign, as: map.campaign.user)
+      wait_for_connection
+      token_element = token_element(token)
+      token_element.click
+      accept_confirm do
+        page.find("body").send_keys :delete
+      end
+      open_token_drawer
+
+      expect(token_drawer).not_to have_token(token)
+      expect(map_element(map)).not_to have_token(token)
+      expect(Token.exists?(token.id)).not_to be true
+      expect_token_actions_disabled
+    end
+
+    it "deletes multiple tokens from the map" do
+      map = create :map, :current
+      token_one = create :token, map: map, stashed: false
+      token_two = create :token, map: map, stashed: false
+
+      visit campaign_path(map.campaign, as: map.campaign.user)
+      wait_for_connection
+      shift_click token_element(token_one)
+      shift_click token_element(token_two)
+      accept_confirm do
+        click_on "Delete"
+      end
+      open_token_drawer
+
+      expect(token_drawer).not_to have_token(token_one)
+      expect(token_drawer).not_to have_token(token_two)
+      expect(map_element(map)).not_to have_token(token_one)
+      expect(map_element(map)).not_to have_token(token_two)
+      expect(Token.exists?(token_one.id)).not_to be true
+      expect(Token.exists?(token_two.id)).not_to be true
+      expect_token_actions_disabled
+    end
+
+    it "deletes the token for other users" do
+      map = create :map, :current
+      token = create :token, map: map, stashed: false
+
+      visit campaign_path(map.campaign, as: map.campaign.user)
+      wait_for_connection
+      using_session "other user" do
+        visit campaign_path(map.campaign)
+        wait_for_connection
+      end
+
+      token_element = token_element(token)
+      token_element.click
+      accept_confirm do
+        click_on "Delete"
+      end
+
+      using_session "other user" do
+        expect(page).not_to have_css(
+          ".token[data-token-id='#{token.to_param}']"
+        )
+      end
+    end
+  end
+
+  def expect_token_actions_enabled
+    page.find_all("[data-target='map--tokens.action']").each do |button|
+      expect(button).not_to be_disabled
+    end
+  end
+
+  def expect_token_actions_disabled
+    expect(page.find_all("[data-target='map--tokens.action']")).to all(
+      be_disabled
+    )
+  end
+end


### PR DESCRIPTION
Closes #104, lays the groundwork for #84, and potentially closes #102 

This PR introduces the ability to select individual or multiple tokens and then take actions on them. Right now the two supported actions are Delete and Stash. Stashing is the same as dragging the token back the drawer, deleting is a new action that we haven't had before, which completely deletes the token from the map. A confirmation dialog is presented before deleting since it's a destructive action, but not for stashing.

Other notes:
* Hold shift (or command on Mac, control on Windows) while clicking to select multiple tokens
* The action buttons are enabled and disabled as you select or unselect tokens.
* It is possible to select and delete tokens that are in the drawer
* It is possible to delete a character from the map. Doing so only deletes it from this map, it will still be in the campaign in the library and on other maps, including automatically added to newly created maps.

To round out the behavior all of this functionality is keyboard accessible:

* Left arrow and right arrow are used to move the selected token
* Hold shift (or command on Mac, control on Windows) while pressing right arrow or left arrow to select multiple tokens using the keyboard
* When tokens are selected, pressing Delete or Backspace will delete them (after confirmation)
* `s` key short stashes the tokens

Here are some videos!

### Select an individual token using the mouse and delete it

![Drawer Select Individual And Delete](https://user-images.githubusercontent.com/5015/92304431-e4e4b180-ef4b-11ea-8835-eebedf6d9e56.gif)

### Select multiple tokens and delete them using the mouse

![Drawer Select Multiple And Delete](https://user-images.githubusercontent.com/5015/92304445-faf27200-ef4b-11ea-81d6-ee1c3459c166.gif)

### Select multiple tokens and stash them using the mouse

![Drawer Select Multiple And Stash](https://user-images.githubusercontent.com/5015/92304451-06de3400-ef4c-11ea-80f8-9a1d825fd0bd.gif)

### Selection and actions work for tokens in the drawer

![Drawer Select And In Drawer](https://user-images.githubusercontent.com/5015/92304459-12c9f600-ef4c-11ea-8a81-3bdd91167b99.gif)

### Select tokens and delete them entirely with the keyboard

![Drawer Select and Delete with Keyboard](https://user-images.githubusercontent.com/5015/92304466-283f2000-ef4c-11ea-9eef-8fafe15fcae1.gif)

### Keyboard selection excluded tokens in the drawer when it's closed and includes them when it is open

![Keyboard Select in Map and Drawer](https://user-images.githubusercontent.com/5015/92304470-355c0f00-ef4c-11ea-8769-bc50962fb80d.gif)

### Toggle the drawer open and closed with a new "t" keyboard shortcut

![Drawer Shortcut](https://user-images.githubusercontent.com/5015/92304481-4c026600-ef4c-11ea-89d5-9c4014d3f4a4.gif)
