### PR TITLE
Individual token editing

### DIFF
--- a/app/channels/maps/tokens_channel.rb
+++ b/app/channels/maps/tokens_channel.rb
@@ -64,6 +64,20 @@ module Maps
         )
       end
 
+      def update_token(token)
+        broadcast_to(
+          token.map,
+          {
+            operation: "updateToken",
+            token_id: token.id,
+            token_html: render_token(token),
+            x: token.x,
+            y: token.y,
+            stashed: token.stashed
+          }
+        )
+      end
+
       private
 
       def render_token(token)

--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -23,9 +23,39 @@ class TokensController < ApplicationController
     end
   end
 
+  def edit
+    respond_to :js
+
+    map = current_user.maps.find(params[:map_id])
+    token = map.tokens.find(params[:id])
+
+    render layout: "modal", locals: { token: token }
+  end
+
+  def update
+    map = current_user.maps.find(params[:map_id])
+    token = map.tokens.find(params[:id])
+    if token.update(token_params)
+      TokenUpdateBroadcastJob.perform_later(token)
+      head :ok
+    else
+      render(
+        partial: "form",
+        locals: { token: token },
+        status: :bad_request
+      )
+    end
+  end
+
   private
 
   def token_params
-    params.require(:token).permit(:name, :image, :token_template_id)
+    params.require(:token).permit(
+      :name,
+      :image,
+      :identifier,
+      :size,
+      :token_template_id
+    )
   end
 end

--- a/app/javascript/controllers/map/tokens_controller.js
+++ b/app/javascript/controllers/map/tokens_controller.js
@@ -70,7 +70,7 @@ export default class extends Controller {
     }
   }
 
-  startMoveToken(event) {
+  moveStarted(event) {
     event.stopPropagation()
     if (this.hasDrawerTarget) {
       this.drawerTarget.dispatchEvent(new CustomEvent('open'))
@@ -78,23 +78,34 @@ export default class extends Controller {
 
     const { target, clientX, clientY } = event
     this.recordPointerLocation(event.clientX, event.clientY)
-    const { left, top } = target.getBoundingClientRect()
 
-    const tokenImage = target.getElementsByClassName("token__image")[0]
-    const { width: tokenWidth, height: tokenHeight } = tokenImage.getBoundingClientRect()
-
-    target.dataset.beingDragged = true
-    target.dataset.offsetX = (tokenWidth / 2) - (clientX - left)
-    target.dataset.offsetY = (tokenHeight / 2) - (clientY - top)
+    this.startMoveToken(target, clientX, clientY)
+    this.selectedTokens().forEach(selectedToken => this.startMoveToken(selectedToken, clientX, clientY))
 
     event.dataTransfer.setData("text/plain", target.dataset.tokenId)
   }
 
-  moveToken(event) {
-    event.stopPropagation()
+  startMoveToken(token, clientX, clientY) {
+    const { left, top } = token.getBoundingClientRect()
 
+    const tokenImage = token.getElementsByClassName("token__image")[0]
+    const { width: tokenWidth, height: tokenHeight } = tokenImage.getBoundingClientRect()
+
+    token.dataset.beingDragged = true
+    token.dataset.offsetX = (tokenWidth / 2) - (clientX - left)
+    token.dataset.offsetY = (tokenHeight / 2) - (clientY - top)
+  }
+
+  moved(event) {
+    event.stopPropagation()
     const { target } = event
-    const { x: currentX, y: currentY, offsetX, offsetY } = target.dataset
+
+    this.moveToken(target)
+    this.performOnSelected(this.moveToken.bind(this), false)
+  }
+
+  moveToken(token) {
+    const { x: currentX, y: currentY, offsetX, offsetY } = token.dataset
     const { zoomAmount } = this.imageTarget.dataset
     const { x, y } = this.mapPositionOf(
       new MouseEvent("drag", {
@@ -108,17 +119,22 @@ export default class extends Controller {
 
     if (newX != currentX || newY != currentY) {
       this.setTokenLocation(
-        target,
+        token,
         newX,
         newY
       )
     }
   }
 
-  endMoveToken({ target }) {
-    delete target.dataset.beingDragged
-    delete target.dataset.offsetX
-    delete target.dataset.offsetY
+  moveEnded({ target }) {
+    this.endMoveToken(target)
+    this.performOnSelected(this.endMoveToken.bind(this), false)
+  }
+
+  endMoveToken(token) {
+    delete token.dataset.beingDragged
+    delete token.dataset.offsetX
+    delete token.dataset.offsetY
   }
 
   setTokenLocation(token, x, y) {
@@ -155,19 +171,23 @@ export default class extends Controller {
 
   dropOnDrawer(event) {
     event.preventDefault()
-    const tokenId = event.dataTransfer.getData("text/plain")
+    const token = this.findToken(event.dataTransfer.getData("text/plain"))
 
-    const token = this.findToken(tokenId)
+    this.stashToken(token)
+    this.performOnSelected(this.stashToken.bind(this))
+
+    this.drawerTarget.dispatchEvent(new CustomEvent('close'))
+  }
+
+  stashToken(token) {
     if (token.parentNode != this.drawerTarget) {
       this.drawerTarget.appendChild(token)
     }
-    this.drawerTarget.dispatchEvent(new CustomEvent('close'))
-
     this.channel.perform(
       "stash_token",
       {
         map_id: this.mapId,
-        token_id: tokenId
+        token_id: token.dataset.tokenId
       }
     )
   }
@@ -178,22 +198,25 @@ export default class extends Controller {
 
   dropOnMap(event) {
     event.preventDefault()
-    const tokenId = event.dataTransfer.getData("text/plain")
-
-    const token = this.findToken(tokenId)
     if (this.hasDrawerTarget) {
       this.drawerTarget.dispatchEvent(new CustomEvent('close'))
     }
+    const token = this.findToken(event.dataTransfer.getData("text/plain"))
+
+    this.placeToken(token)
+    this.performOnSelected(this.placeToken.bind(this))
+  }
+
+  placeToken(token) {
     if (token.parentNode != this.containerTarget) {
       if (token.dataset.copyOnPlace != "true") {
         this.containerTarget.appendChild(token)
       }
-
       this.channel.perform(
         "place_token",
         {
           map_id: this.mapId,
-          token_id: tokenId
+          token_id: token.dataset.tokenId
         }
       )
     }
@@ -258,10 +281,8 @@ export default class extends Controller {
 
   selectWithKeyboard(event) {
     var index = 0
-    var selectedTokens = this.tokenTargets.filter(token => {
-      return token.dataset.selected
-    })
-    var availableTokens = this.tokenTargets.filter(token => {
+    const selectedTokens = this.selectedTokens()
+    const availableTokens = this.tokenTargets.filter(token => {
       if (this.hasDrawerTarget && !this.drawerTarget.classList.contains("show") && token.parentNode == this.drawerTarget) {
         return false
       } else {
@@ -300,36 +321,32 @@ export default class extends Controller {
     return this.tokenTargets.some(token => { return token.dataset.selected })
   }
 
+  selectedTokens() {
+    return this.tokenTargets.filter(token => token.dataset.selected)
+  }
+
   toggleTokenActions() {
     if (this.hasActionsTarget) {
-      this.actionTargets.forEach(action => {
-        action.disabled = !this.hasTokenSelected()
-      })
+      this.actionTargets.forEach(action => action.disabled = !this.hasTokenSelected())
     }
   }
 
   deleteSelected() {
     if (this.hasTokenSelected() && confirm(`Are you sure you want to delete the selected tokens?`)) {
-      this.tokenTargets.forEach(token => {
-        if (token.dataset.selected) {
-          this.unselectToken(token)
-          this.channel.perform(
-            "delete_token",
-            { map_id: this.mapId, token_id: token.dataset.tokenId }
-          )
-        }
+      this.performOnSelected(token => {
+        this.channel.perform(
+          "delete_token",
+          { map_id: this.mapId, token_id: token.dataset.tokenId }
+        )
       })
     }
   }
 
-  stashSelected() {
-    this.tokenTargets.forEach(token => {
-      if (token.dataset.selected) {
+  performOnSelected(operation, unselectAfterOperation = true) {
+    this.selectedTokens().forEach(token => {
+      operation(token)
+      if (unselectAfterOperation) {
         this.unselectToken(token)
-        this.channel.perform(
-          "stash_token",
-          { map_id: this.mapId, token_id: token.dataset.tokenId }
-        )
       }
     })
     if (this.selectedTokens.includes(clickedToken)) {
@@ -354,16 +371,17 @@ export default class extends Controller {
     }
   }
 
+  stashSelected() {
+    this.performOnSelected(this.stashToken.bind(this))
+  }
+
   editSelected() {
-    this.tokenTargets.forEach(token => {
-      if (token.dataset.selected) {
-        this.unselectToken(token)
-        Rails.ajax({
-          type: 'GET',
-          url: token.dataset.editUrl,
-          dataType: "script"
-        })
-      }
+    this.performOnSelected(token => {
+      Rails.ajax({
+        type: 'GET',
+        url: token.dataset.editUrl,
+        dataType: "script"
+      })
     })
   }
 

--- a/app/javascript/src/components/_map.scss
+++ b/app/javascript/src/components/_map.scss
@@ -22,6 +22,15 @@
       @apply opacity-50;
     }
   }
+
+  .action {
+    @apply opacity-100;
+    transition: opacity 0.2s ease-in-out;
+
+    &:disabled {
+      @apply opacity-50;
+    }
+  }
 }
 
 .current-map__image {

--- a/app/jobs/token_creation_broadcast_job.rb
+++ b/app/jobs/token_creation_broadcast_job.rb
@@ -1,4 +1,4 @@
-class TokenBroadcastJob < ApplicationJob
+class TokenCreationBroadcastJob < ApplicationJob
   queue_as :default
 
   def perform(token)

--- a/app/jobs/token_update_broadcast_job.rb
+++ b/app/jobs/token_update_broadcast_job.rb
@@ -1,0 +1,7 @@
+class TokenUpdateBroadcastJob < ApplicationJob
+  queue_as :default
+
+  def perform(token)
+    Maps::TokensChannel.update_token(token)
+  end
+end

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -45,6 +45,6 @@ class Token < ApplicationRecord
   private
 
   def broadcast_token_creation
-    TokenBroadcastJob.perform_later(self)
+    TokenCreationBroadcastJob.perform_later(self)
   end
 end

--- a/app/views/campaigns/_current_map.html.erb
+++ b/app/views/campaigns/_current_map.html.erb
@@ -70,6 +70,9 @@
           <%= button_tag class: "action flex-initial block rounded-md border mr-1 px-2 text-sm bg-gray-200 hover:bg-gray-400 active:bg-gray-600 relative", data: { target: "map--tokens.action", action: "map--tokens#stashSelected" }, disabled: true, title: "Stash" do %>
             Stash
           <% end %>
+          <%= button_tag class: "action flex-initial block rounded-md border mr-1 px-2 text-sm bg-gray-200 hover:bg-gray-400 active:bg-gray-600 relative", data: { target: "map--tokens.action", action: "map--tokens#editSelected" }, disabled: true, title: "Edit" do %>
+            Edit
+          <% end %>
         </div>
       <% end %>
     <% end %>

--- a/app/views/tokens/_form.html.erb
+++ b/app/views/tokens/_form.html.erb
@@ -1,0 +1,20 @@
+<%= form_with model: [token.map.campaign, token.map, token], html: { data: { action: "ajax:success->modal#close ajax:error->modal#onPostError" } } do |form| %>
+  <%= render "errors", model: token %>
+
+  <%= form.label :name %>
+  <%= form.text_field :name, class: "input" %>
+
+  <%= form.label :identifier %>
+  <%= form.text_field :identifier, class: "input" %>
+
+  <%= form.label :size %>
+  <%= form.select :size, options_for_token_size, {}, class: "input" %>
+
+  <%= form.label :image %>
+  <%= form.file_field :image, class: "input" %>
+
+  <div class="flex items-center justify-between">
+    <%= form.submit class: "btn" %>
+    <%= link_to "Cancel", "#", data: { action: "click->modal#close" }, class: "inline-block align-baseline text-sm text-gray-500 hover:text-gray-800" %>
+  </div>
+<% end %>

--- a/app/views/tokens/_token.html.erb
+++ b/app/views/tokens/_token.html.erb
@@ -6,6 +6,7 @@
     target: "map--tokens.token",
     action: "dragenter->map--tokens#dragOverToken dragstart->map--tokens#startMoveToken drag->map--tokens#moveToken dragend->map--tokens#endMoveToken click->map--tokens#toggleTokenSelect mousedown->map--tokens#stopPropagation",
     token_id: token.id,
+    edit_url: edit_campaign_map_token_path(token.map.campaign, token.map, token),
     x: token.x,
     y: token.y,
     "size-scale": token.size_scale,

--- a/app/views/tokens/_token.html.erb
+++ b/app/views/tokens/_token.html.erb
@@ -4,7 +4,7 @@
   data: {
     controller: "css-var sync-values",
     target: "map--tokens.token",
-    action: "dragenter->map--tokens#dragOverToken dragstart->map--tokens#startMoveToken drag->map--tokens#moveToken dragend->map--tokens#endMoveToken click->map--tokens#toggleTokenSelect mousedown->map--tokens#stopPropagation",
+    action: "dragenter->map--tokens#dragOverToken dragstart->map--tokens#moveStarted drag->map--tokens#moved dragend->map--tokens#moveEnded click->map--tokens#toggleTokenSelect mousedown->map--tokens#stopPropagation",
     token_id: token.id,
     edit_url: edit_campaign_map_token_path(token.map.campaign, token.map, token),
     x: token.x,

--- a/app/views/tokens/edit.html.erb
+++ b/app/views/tokens/edit.html.erb
@@ -1,0 +1,15 @@
+<div class="p-4">
+  <h1 class="text-2xl">Edit <%= token.name %></h1>
+
+  <hr class="my-2" />
+
+  <% if token.token_template.present? %>
+    <div class="rounded text-sm text-white bg-blue-500 p-2 mb-3">
+      You are editing this individual token for this <%= token.token_template.type %> on this map.
+      If you would like to edit it across all maps, you can do so
+      <%= link_to "here", polymorphic_url([token.map.campaign, token.token_template], action: :edit), remote: true, data: { action: "click->modal#removeModal" }, class: "underline" %>.
+    </div>
+  <% end %>
+
+  <%= render "form", token: token %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
     resources :characters, only: %i[create edit update destroy]
     resources :creatures, only: %i[create edit update destroy]
     resources :maps, only: %i[new create edit update destroy] do
-      resources :tokens, only: %i[new create]
+      resources :tokens, only: %i[new create edit update]
     end
   end
 

--- a/spec/system/move_tokens_spec.rb
+++ b/spec/system/move_tokens_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "move tokens", type: :system do
     expect(page).to have_token_with_data(token, "token-id", token.id)
   end
 
-  it "drags tokens" do
+  it "drags token" do
     map = create :map, :current, zoom: 2
     token = create :token, map: map, x: 0, y: 0, stashed: false
 
@@ -21,6 +21,23 @@ RSpec.describe "move tokens", type: :system do
 
     expect(page).to have_token_with_data(token, "x", 50)
     expect(page).to have_token_with_data(token, "y", 50)
+  end
+
+  it "drags multiple selected tokens" do
+    map = create :map, :current, zoom: 2
+    token_one = create :token, map: map, x: 0, y: 0, stashed: false
+    token_two = create :token, map: map, x: 100, y: 100, stashed: false
+
+    visit campaign_path(map.campaign)
+    wait_for_connection
+    shift_click token_element(token_one)
+    shift_click token_element(token_two)
+    click_and_move_token(token_one, by: { x: 50, y: 50 })
+
+    expect(page).to have_token_with_data(token_one, "x", 50)
+    expect(page).to have_token_with_data(token_one, "y", 50)
+    expect(page).to have_token_with_data(token_two, "x", 150)
+    expect(page).to have_token_with_data(token_two, "y", 150)
   end
 
   it "factors in map zoom when dragging" do
@@ -51,6 +68,30 @@ RSpec.describe "move tokens", type: :system do
     using_session "other user" do
       expect(page).to have_token_with_data(token, "x", 50)
       expect(page).to have_token_with_data(token, "y", 50)
+    end
+  end
+
+  it "moves multiple tokens for other users" do
+    map = create :map, :current, zoom: 2
+    token_one = create :token, map: map, x: 0, y: 0, stashed: false
+    token_two = create :token, map: map, x: 100, y: 100, stashed: false
+
+    visit campaign_path(map.campaign)
+    wait_for_connection
+    using_session "other user" do
+      visit campaign_path(map.campaign)
+      wait_for_connection
+    end
+
+    shift_click token_element(token_one)
+    shift_click token_element(token_two)
+    click_and_move_token(token_one, by: { x: 50, y: 50 })
+
+    using_session "other user" do
+      expect(page).to have_token_with_data(token_one, "x", 50)
+      expect(page).to have_token_with_data(token_one, "y", 50)
+      expect(page).to have_token_with_data(token_two, "x", 150)
+      expect(page).to have_token_with_data(token_two, "y", 150)
     end
   end
 end

--- a/spec/system/token_drawer_spec.rb
+++ b/spec/system/token_drawer_spec.rb
@@ -40,10 +40,26 @@ RSpec.describe "token drawer", type: :system do
     wait_for_connection
     token_element = token_element(token)
     token_element.drag_to(token_drawer, html5: true)
-    open_token_drawer
 
     expect(token_drawer).to have_token(token)
     expect(map_element(map)).not_to have_token(token)
+  end
+
+  it "moves multiple tokens from the map to the drawer" do
+    map = create :map, :current
+    token_one = create :token, map: map, stashed: false
+    token_two = create :token, map: map, stashed: false
+
+    visit campaign_path(map.campaign, as: map.campaign.user)
+    wait_for_connection
+    shift_click token_element(token_one)
+    shift_click token_element(token_two)
+    token_element(token_one).drag_to(token_drawer, html5: true)
+
+    expect(token_drawer).to have_token(token_one)
+    expect(map_element(map)).not_to have_token(token_one)
+    expect(token_drawer).to have_token(token_two)
+    expect(map_element(map)).not_to have_token(token_two)
   end
 
   it "hides the token for other users" do
@@ -62,6 +78,28 @@ RSpec.describe "token drawer", type: :system do
 
     using_session "other user" do
       expect(page).not_to have_token(token)
+    end
+  end
+
+  it "hides multiple tokens for other users" do
+    map = create :map, :current
+    token_one = create :token, map: map, stashed: false
+    token_two = create :token, map: map, stashed: false
+
+    visit campaign_path(map.campaign, as: map.campaign.user)
+    wait_for_connection
+    using_session "other user" do
+      visit campaign_path(map.campaign)
+      wait_for_connection
+    end
+
+    shift_click token_element(token_one)
+    shift_click token_element(token_two)
+    token_element(token_one).drag_to(token_drawer, html5: true)
+
+    using_session "other user" do
+      expect(page).not_to have_token(token_one)
+      expect(page).not_to have_token(token_two)
     end
   end
 end


### PR DESCRIPTION
Builds on #113 to introduce the ability to edit the details of an individual token and then have that broadcast to all players. You can edit the name, identifier, size, and the image of the token. The keyboard short for this is `e`.

This also potentially helps with #99, allowing DMs to swap out the image on a token during play, though you'd need to keep the files handy.

When you edit the token, you're editing that individual instance of the token, and it doesn't affect the other tokens on the map or campaign. When a token is from a template (which is all tokens) we display a link to edit the template from this screen.

Changing the template is not something that is currently broadcast.

![Edit Token](https://user-images.githubusercontent.com/5015/92325399-6570e400-f018-11ea-8902-e77cf1aee706.gif)