### PR TITLE
Move multiple tokens

### DIFF
--- a/app/views/tokens/_token.html.erb
+++ b/app/views/tokens/_token.html.erb
@@ -4,7 +4,7 @@
   data: {
     controller: "css-var sync-values",
     target: "map--tokens.token",
-    action: "dragenter->map--tokens#dragOverToken dragstart->map--tokens#startMoveToken drag->map--tokens#moveToken dragend->map--tokens#endMoveToken click->map--tokens#toggleTokenSelect mousedown->map--tokens#stopPropagation",
+    action: "dragenter->map--tokens#dragOverToken dragstart->map--tokens#moveStarted drag->map--tokens#moved dragend->map--tokens#moveEnded click->map--tokens#toggleTokenSelect mousedown->map--tokens#stopPropagation",
     token_id: token.id,
     edit_url: edit_campaign_map_token_path(token.map.campaign, token.map, token),
     x: token.x,

--- a/spec/system/move_tokens_spec.rb
+++ b/spec/system/move_tokens_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "move tokens", type: :system do
     expect(page).to have_token_with_data(token, "token-id", token.id)
   end
 
-  it "drags tokens" do
+  it "drags token" do
     map = create :map, :current, zoom: 2
     token = create :token, map: map, x: 0, y: 0, stashed: false
 
@@ -21,6 +21,23 @@ RSpec.describe "move tokens", type: :system do
 
     expect(page).to have_token_with_data(token, "x", 50)
     expect(page).to have_token_with_data(token, "y", 50)
+  end
+
+  it "drags multiple selected tokens" do
+    map = create :map, :current, zoom: 2
+    token_one = create :token, map: map, x: 0, y: 0, stashed: false
+    token_two = create :token, map: map, x: 100, y: 100, stashed: false
+
+    visit campaign_path(map.campaign)
+    wait_for_connection
+    shift_click token_element(token_one)
+    shift_click token_element(token_two)
+    click_and_move_token(token_one, by: { x: 50, y: 50 })
+
+    expect(page).to have_token_with_data(token_one, "x", 50)
+    expect(page).to have_token_with_data(token_one, "y", 50)
+    expect(page).to have_token_with_data(token_two, "x", 150)
+    expect(page).to have_token_with_data(token_two, "y", 150)
   end
 
   it "factors in map zoom when dragging" do
@@ -51,6 +68,30 @@ RSpec.describe "move tokens", type: :system do
     using_session "other user" do
       expect(page).to have_token_with_data(token, "x", 50)
       expect(page).to have_token_with_data(token, "y", 50)
+    end
+  end
+
+  it "moves multiple tokens for other users" do
+    map = create :map, :current, zoom: 2
+    token_one = create :token, map: map, x: 0, y: 0, stashed: false
+    token_two = create :token, map: map, x: 100, y: 100, stashed: false
+
+    visit campaign_path(map.campaign)
+    wait_for_connection
+    using_session "other user" do
+      visit campaign_path(map.campaign)
+      wait_for_connection
+    end
+
+    shift_click token_element(token_one)
+    shift_click token_element(token_two)
+    click_and_move_token(token_one, by: { x: 50, y: 50 })
+
+    using_session "other user" do
+      expect(page).to have_token_with_data(token_one, "x", 50)
+      expect(page).to have_token_with_data(token_one, "y", 50)
+      expect(page).to have_token_with_data(token_two, "x", 150)
+      expect(page).to have_token_with_data(token_two, "y", 150)
     end
   end
 end

--- a/spec/system/token_drawer_spec.rb
+++ b/spec/system/token_drawer_spec.rb
@@ -46,6 +46,24 @@ RSpec.describe "token drawer", type: :system do
     expect(map_element(map)).not_to have_token(token)
   end
 
+  it "moves multiple tokens from the map to the drawer" do
+    map = create :map, :current
+    token_one = create :token, map: map, stashed: false
+    token_two = create :token, map: map, stashed: false
+
+    visit campaign_path(map.campaign, as: map.campaign.user)
+    wait_for_connection
+    shift_click token_element(token_one)
+    shift_click token_element(token_two)
+    token_element(token_one).drag_to(token_drawer, html5: true)
+    open_token_drawer
+
+    expect(token_drawer).to have_token(token_one)
+    expect(map_element(map)).not_to have_token(token_one)
+    expect(token_drawer).to have_token(token_two)
+    expect(map_element(map)).not_to have_token(token_two)
+  end
+
   it "hides the token for other users" do
     map = create :map, :current
     token = create :token, map: map, stashed: false
@@ -62,6 +80,28 @@ RSpec.describe "token drawer", type: :system do
 
     using_session "other user" do
       expect(page).not_to have_token(token)
+    end
+  end
+
+  it "hides multiple tokens for other users" do
+    map = create :map, :current
+    token_one = create :token, map: map, stashed: false
+    token_two = create :token, map: map, stashed: false
+
+    visit campaign_path(map.campaign, as: map.campaign.user)
+    wait_for_connection
+    using_session "other user" do
+      visit campaign_path(map.campaign)
+      wait_for_connection
+    end
+
+    shift_click token_element(token_one)
+    shift_click token_element(token_two)
+    token_element(token_one).drag_to(token_drawer, html5: true)
+
+    using_session "other user" do
+      expect(page).not_to have_token(token_one)
+      expect(page).not_to have_token(token_two)
     end
   end
 end


### PR DESCRIPTION
Closes #84 

Allows you to select tokens and move them together, both around the map and to and from the drawer.

![Move Multiple](https://user-images.githubusercontent.com/5015/93005759-1e0bbb80-f522-11ea-9b5f-08e5bab4266c.gif)

Preserves the old behavior of not needing to select an individual token to move it.